### PR TITLE
feature(openapi): Guess route prefix from servers schema.

### DIFF
--- a/examples/hobotnica/app.py
+++ b/examples/hobotnica/app.py
@@ -28,5 +28,4 @@ def create_app(
         ),
         Path(__file__).parent / "openapi.yaml",
         views.operations,
-        route_prefix="/api",
     )

--- a/examples/hobotnica/openapi.yaml
+++ b/examples/hobotnica/openapi.yaml
@@ -2,6 +2,8 @@ openapi: "3.0.2"
 
 info:
   title: "Hobotnica API"
+  description: |
+    Reduced Hobotnica API schema as rororo example app.
   version: "1.0.0"
   contact:
     name: "Igor Davydenko (developer)"

--- a/examples/petstore/app.py
+++ b/examples/petstore/app.py
@@ -70,9 +70,6 @@ def create_app(
         Path(__file__).parent / "petstore-expanded.yaml",
         # And after list of operations
         views.operations,
-        # Need to add route prefix if server URL in OpenAPI schema ended with
-        # a path, like "http://localhost:8080/api"
-        route_prefix="/api",
     )
 
     return app

--- a/tests/openapi.json
+++ b/tests/openapi.json
@@ -15,7 +15,12 @@
   },
   "servers": [
     {
-      "url": "/api"
+      "url": "/api",
+      "x-rororo-level": "test"
+    },
+    {
+      "url": "/dev-api",
+      "x-rororo-level": ["dev"]
     }
   ],
   "paths": {

--- a/tests/openapi.yaml
+++ b/tests/openapi.yaml
@@ -13,6 +13,10 @@ info:
 
 servers:
   - url: "/api"
+    x-rororo-level: "test"
+
+  - url: "/dev-api"
+    x-rororo-level: ["dev"]
 
 paths:
   "/hello":


### PR DESCRIPTION
Completely remove `route_prefix` keyword arg from `setup_openapi` func, use `server_url` instead.

Other way of setting up server URL to use is wrapping `aiohttp.web` application into `setup_settings` and marking each server schema definition with custom `x-rororo-level` key.

Fixes: #23