### PR TITLE
fix(openapi): Use custom path finder

### DIFF
--- a/examples/hobotnica/data.py
+++ b/examples/hobotnica/data.py
@@ -13,3 +13,11 @@ GITHUB_REPOSITORIES = {
         }
     }
 }
+
+ENVIRONMENT_VARS = {
+    GITHUB_USERNAME: {
+        "HOME": f"/home/{GITHUB_USERNAME}",
+        "TIME_ZONE": "Europe/Kiev",
+    },
+    f"{GITHUB_USERNAME}/{GITHUB_REPOSITORY}": {"LOCALE": "uk_UA.UTF-8"},
+}

--- a/examples/hobotnica/openapi.yaml
+++ b/examples/hobotnica/openapi.yaml
@@ -20,8 +20,7 @@ paths:
   "/repositories":
     get:
       operationId: "list_repositories"
-      tags:
-        - "repositories"
+      tags: ["repositories"]
       summary: "List user repositories registered in Hobotnica."
       parameters:
         - $ref: "#/components/parameters/GitHubUsername"
@@ -40,8 +39,7 @@ paths:
 
     post:
       operationId: "create_repository"
-      tags:
-        - "repositories"
+      tags: ["repositories"]
       summary: "Add new user repository to Hobotnica."
       parameters:
         - $ref: "#/components/parameters/GitHubUsername"
@@ -60,11 +58,47 @@ paths:
       security:
         - personalToken: []
 
+  "/repositories/{owner}":
+    get:
+      operationId: "list_owner_repositories"
+      tags: ["repositories"]
+      summary: "List repositories owned by user."
+      parameters:
+        - $ref: "#/components/parameters/RepositoryOwner"
+      responses:
+        "200":
+          description: "Repositories list."
+          content:
+            application/json:
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/Repository"
+      security:
+        - basic: []
+
+  "/repositories/{owner}/env":
+    get:
+      operationId: "retrieve_owner_env"
+      tags: ["environment"]
+      summary: "Retrieve common environment vars for user."
+      parameters:
+        - $ref: "#/components/parameters/RepositoryOwner"
+      responses:
+        "200":
+          description: "Owner environment vars."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AnyObject"
+      security:
+        - basic: []
+
   "/repositories/{owner}/{name}":
     get:
       operationId: "retrieve_repository"
       tags:
-        - repositories
+        - "repositories"
       summary: "Retrieve details of user repository."
       parameters:
         - $ref: "#/components/parameters/GitHubUsername"
@@ -81,28 +115,32 @@ paths:
         - jwt: []
           personalToken: []
 
-  "/repositories/{owner}":
+  "/repositories/{owner}/{name}/env":
     get:
-      operationId: "list_owner_repositories"
+      operationId: "retrieve_repository_env"
       tags:
-        - repositories
-      summary: "List repositories owned by user."
+        - "environment"
+      summary: "Retrieve common env vars for the repository"
       parameters:
+        - $ref: "#/components/parameters/GitHubUsername"
         - $ref: "#/components/parameters/RepositoryOwner"
+        - $ref: "#/components/parameters/RepositoryName"
       responses:
         "200":
-          description: "Repositories list."
+          description: "Repository environment vars."
           content:
             application/json:
               schema:
-                type: "array"
-                items:
-                  $ref: "#/components/schemas/Repository"
+                $ref: "#/components/schemas/AnyObject"
       security:
-        - basic: []
+        - personalToken: []
 
 components:
   schemas:
+    AnyObject:
+      type: "object"
+      additionalProperties: true
+
     RepositoryOwner:
       type: "string"
       minLength: 1
@@ -186,3 +224,6 @@ components:
 tags:
   - name: "repositories"
     description: "Repositories endpoints."
+
+  - name: "environment"
+    description: "Environment endpoints."

--- a/examples/hobotnica/views.py
+++ b/examples/hobotnica/views.py
@@ -4,7 +4,7 @@ from aiohttp import web
 
 from rororo import openapi_context, OperationTableDef
 from rororo.openapi.exceptions import ObjectDoesNotExist
-from .data import GITHUB_REPOSITORIES
+from .data import ENVIRONMENT_VARS, GITHUB_REPOSITORIES
 from .decorators import login_required
 
 
@@ -48,6 +48,14 @@ async def list_repositories(request: web.Request) -> web.Response:
 
 @operations.register
 @login_required
+async def retrieve_owner_env(request: web.Request) -> web.Response:
+    with openapi_context(request) as context:
+        owner = context.parameters.path["owner"]
+        return web.json_response(ENVIRONMENT_VARS.get(owner) or {})
+
+
+@operations.register
+@login_required
 async def retrieve_repository(request: web.Request) -> web.Response:
     with openapi_context(request) as context:
         owner = context.parameters.path["owner"]
@@ -59,3 +67,13 @@ async def retrieve_repository(request: web.Request) -> web.Response:
             raise ObjectDoesNotExist("Repository")
 
         return web.json_response(repository)
+
+
+@operations.register
+@login_required
+async def retrieve_repository_env(request: web.Request) -> web.Response:
+    with openapi_context(request) as context:
+        owner = context.parameters.path["owner"]
+        name = context.parameters.path["name"]
+        env_key = f"{owner}/{name}"
+        return web.json_response(ENVIRONMENT_VARS.get(env_key) or {})

--- a/rororo/openapi/data.py
+++ b/rororo/openapi/data.py
@@ -10,6 +10,7 @@ from openapi_core.validation.request.datatypes import (
     RequestParameters,
 )
 from openapi_core.validation.response.datatypes import OpenAPIResponse
+from yarl import URL
 
 from ..annotations import DictStrAny, MappingStrAny
 
@@ -87,7 +88,8 @@ class OpenAPIContext:
 
 
 def get_full_url_pattern(request: web.Request) -> str:
-    return str(request.url.with_path(get_path_pattern(request)))
+    full_url: URL = request.url.with_path(get_path_pattern(request))
+    return full_url.human_repr()
 
 
 def get_path_pattern(request: web.Request) -> str:
@@ -103,7 +105,7 @@ def get_path_pattern(request: web.Request) -> str:
     )
 
 
-async def to_core_openapi_request(request: web.Request,) -> OpenAPIRequest:
+async def to_core_openapi_request(request: web.Request) -> OpenAPIRequest:
     """Convert aiohttp.web request to openapi-core request.
 
     Afterwards opeanpi-core request can be used for validation request data


### PR DESCRIPTION
To ensure proper logic behind matching current request to OpenAPI operation to use.

`openapi-core==0.13.3` version ships with `openapi_core.templating.paths.finders.PathFinder` class, which finds too many paths if OpenAPI schema contains multiple paths with variables.

Given commit customize path finder logic to not return first result of `PathFinder._get_servers_iter(...)` call, but to match that current request full URL pattern ends with `Path.name`.

After fixing https://github.com/p1c2u/openapi-core/issues/226, this code might be not needed anymore.

Also provide docstrings for reason behind providing custom classes for validation, unmarshalling data, etc.