### PR TITLE
feature(openapi): Support class based views as well

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@
 2.0.0rc0 (In Development)
 -------------------------
 
+- feature: Support class based views as well
 - feature: Allow to pass kwargs to error middleware as done for CORS middleware
 - feature: Ensure support optional security schemes
 - feature: Integrate `environ-config <https://environ-config.readthedocs.io>`_

--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,26 @@ schema file.
         )
         return app
 
+Class Based Views
+-----------------
+
+``rororo`` supports `class based views <https://docs.aiohttp.org/en/stable/web_quickstart.html#aiohttp-web-class-based-views>`_
+as well. `Todo-Backend <https://github.com/playpauseandstop/rororo/tree/master/examples/todobackend>`_
+example illustrates how to use class based views for OpenAPI handlers.
+
+In snippet below, ``rororo`` expects that OpenAPI schema contains operation ID
+``UserView.get``,
+
+.. code-block:: python
+
+    @operations.register
+    class UserView(web.View):
+        async def get(self) -> web.Response:
+            ...
+
+More Examples
+-------------
+
 Check
 `examples <https://github.com/playpauseandstop/rororo/tree/master/examples>`_
 folder to see other examples on how to use OpenAPI 3 schemas with aiohttp.web

--- a/examples/todobackend/data.py
+++ b/examples/todobackend/data.py
@@ -1,5 +1,4 @@
 import uuid
-from random import choice
 
 import attr
 from aiohttp import web
@@ -35,9 +34,8 @@ class Todo:
         )
 
     def get_absolute_url(self, *, request: web.Request) -> URL:
-        route_name = choice(["retrieve_todo", "update_todo", "delete_todo"])
         return request.url.with_path(  # type: ignore
-            str(request.app.router[route_name].url_for(todo_uid=str(self.uid)))
+            str(request.app.router["todo.get"].url_for(todo_uid=str(self.uid)))
         )
 
     def to_api_dict(self, *, request: web.Request) -> TodoAPIDict:

--- a/examples/todobackend/openapi.yaml
+++ b/examples/todobackend/openapi.yaml
@@ -31,7 +31,7 @@ x-default-responses: &default_responses
 paths:
   "/":
     post:
-      operationId: "create_todo"
+      operationId: "TodosView.post"
       summary: "Add new todo"
       tags: ["todos"]
       requestBody:
@@ -49,7 +49,7 @@ paths:
                 $ref: "#/components/schemas/Todo"
 
     get:
-      operationId: "list_todos"
+      operationId: "TodosView.get"
       summary: "List all todos"
       tags: ["todos"]
       responses:
@@ -64,7 +64,7 @@ paths:
                   $ref: "#/components/schemas/Todo"
 
     delete:
-      operationId: "delete_todos"
+      operationId: "TodosView.delete"
       summary: "Delete all todos"
       tags: ["todos"]
       responses:
@@ -74,7 +74,7 @@ paths:
 
   "/{todo_uid}":
     get:
-      operationId: "retrieve_todo"
+      operationId: "todo.get"
       summary: "Retrieve todo by ID"
       tags: ["todos"]
       parameters:
@@ -89,7 +89,7 @@ paths:
                 $ref: "#/components/schemas/Todo"
 
     patch:
-      operationId: "update_todo"
+      operationId: "todo.patch"
       summary: "Update todo details"
       tags: ["todos"]
       parameters:
@@ -109,7 +109,7 @@ paths:
                 $ref: "#/components/schemas/Todo"
 
     delete:
-      operationId: "delete_todo"
+      operationId: "todo.delete"
       summary: "Delete todo by ID"
       tags: ["todos"]
       parameters:

--- a/examples/todobackend/tests.py
+++ b/examples/todobackend/tests.py
@@ -16,6 +16,7 @@ from todobackend.storage import Storage
 from yarl import URL
 
 
+FAKE_UID = "b3f8d6d7-f4a5-44bb-ba36-85a6579b63c0"
 TEST_TITLE = "New todo"
 URL_TODOS = URL("/todos/")
 
@@ -123,3 +124,19 @@ async def test_storage(todobackend_redis, todobackend_settings):
 
         assert await storage.delete_todo(todo) == 0
         assert await storage.delete_todos() == 0
+
+
+@pytest.mark.parametrize(
+    "route_name, kwargs, expected",
+    (
+        ("TodosView.delete", {}, URL_TODOS),
+        ("TodosView.get", {}, URL_TODOS),
+        ("TodosView.post", {}, URL_TODOS),
+        ("todo.delete", {"todo_uid": FAKE_UID}, URL_TODOS / FAKE_UID),
+        ("todo.get", {"todo_uid": FAKE_UID}, URL_TODOS / FAKE_UID),
+        ("todo.patch", {"todo_uid": FAKE_UID}, URL_TODOS / FAKE_UID),
+    ),
+)
+async def test_url(route_name, kwargs, expected):
+    app = create_app()
+    assert app.router[route_name].url_for(**kwargs) == expected

--- a/rororo/openapi/openapi.py
+++ b/rororo/openapi/openapi.py
@@ -162,7 +162,9 @@ class OperationTableDef:
             except TypeError:
                 return register_handler(handler_or_view)
 
-            return handler_or_view
+            # Python 3.6 do not raise a TypeError for checking whether plain
+            # handler is a subclass of `web.View`, but Python 3.7+ does
+            return register_handler(handler_or_view)
 
         return decorator(mixed) if callable(mixed) else decorator
 


### PR DESCRIPTION
Ensure class based views is able to decorate with `@operations.register`

As of now it supports 2 modes,

1. When OpenAPI schema contains operation ID of `ViewMethod.__qualname__`
2. When OpenAPI schema contains operation ID of `<base>.<ViewMethod.__name__>`

Going forward it will be added 3rd mode to support decorating both `web.View`
and `ViewMethod` to allow register operation ID of custom name for the
`ViewMethod`.

----

In,

```python
class UserView(web.View):
    async def get(self) -> web.Response:
        ...
```

`ViewMethod.__qualname__` is `UserView.get`.

Issue: #45