### PR TITLE
feature(openapi): Support custom operation ID on registering view method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@
 2.0.0rc0 (In Development)
 -------------------------
 
-- feature: Support class based views as well
+- feature: Support class based views
 - feature: Allow to pass kwargs to error middleware as done for CORS middleware
 - feature: Ensure support optional security schemes
 - feature: Integrate `environ-config <https://environ-config.readthedocs.io>`_
@@ -16,7 +16,7 @@
   call
 - feature: Use `email-validator <https://pypi.org/project/email-validator>`_
   for validating string fields with ``format: "email"``
-- feature: Validating error responses via OpenAPI schema as well
+- feature: Validating error responses via OpenAPI schema
 
 2.0.0b3 (2020-01-27)
 --------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,6 +15,9 @@ OpenAPI
 .. autofunction:: rororo.openapi.get_validated_data
 .. autofunction:: rororo.openapi.get_validated_parameters
 
+.. automodule:: rororo.openapi.data
+.. autoclass:: rororo.openapi.data.OpenAPIContext
+
 Settings
 ========
 

--- a/examples/todobackend/openapi.yaml
+++ b/examples/todobackend/openapi.yaml
@@ -31,7 +31,7 @@ x-default-responses: &default_responses
 paths:
   "/":
     post:
-      operationId: "TodosView.post"
+      operationId: "create_todo"
       summary: "Add new todo"
       tags: ["todos"]
       requestBody:
@@ -49,7 +49,7 @@ paths:
                 $ref: "#/components/schemas/Todo"
 
     get:
-      operationId: "TodosView.get"
+      operationId: "list_todos"
       summary: "List all todos"
       tags: ["todos"]
       responses:

--- a/examples/todobackend/tests.py
+++ b/examples/todobackend/tests.py
@@ -129,9 +129,9 @@ async def test_storage(todobackend_redis, todobackend_settings):
 @pytest.mark.parametrize(
     "route_name, kwargs, expected",
     (
+        ("create_todo", {}, URL_TODOS),
+        ("list_todos", {}, URL_TODOS),
         ("TodosView.delete", {}, URL_TODOS),
-        ("TodosView.get", {}, URL_TODOS),
-        ("TodosView.post", {}, URL_TODOS),
         ("todo.delete", {"todo_uid": FAKE_UID}, URL_TODOS / FAKE_UID),
         ("todo.get", {"todo_uid": FAKE_UID}, URL_TODOS / FAKE_UID),
         ("todo.patch", {"todo_uid": FAKE_UID}, URL_TODOS / FAKE_UID),

--- a/examples/todobackend/views.py
+++ b/examples/todobackend/views.py
@@ -13,12 +13,24 @@ operations = OperationTableDef()
 
 @operations.register
 class TodosView(web.View):
+    """Illustrate how to register operations to ``web.View``.
+
+    Basic method allows to map ``ViewMethod.__qualname__`` to ``operationId``
+    in OpenAPI schema. Cause of that ``TodosView.delete`` is not additionally
+    decorated.
+
+    Advanced method allows to provide custom ``operationId`` for
+    ``ViewMethod``, cause of that ``TodosView.get`` and ``TodosView.post``
+    decorated with ``@operations.register(operation_id)`` as well.
+    """
+
     async def delete(self) -> web.Response:
         storage: Storage = self.request.config_dict[APP_STORAGE_KEY]
         await storage.delete_todos()
 
         return web.json_response("")
 
+    @operations.register("list_todos")
     async def get(self) -> web.Response:
         request = self.request
 
@@ -29,6 +41,7 @@ class TodosView(web.View):
             [item.to_api_dict(request=request) for item in todos]
         )
 
+    @operations.register("create_todo")
     async def post(self) -> web.Response:
         request = self.request
 

--- a/rororo/annotations.py
+++ b/rororo/annotations.py
@@ -9,20 +9,24 @@ place.
 """
 
 import types
-from typing import Any, Callable, Dict, Mapping, TypeVar, Union
+from typing import Any, Callable, Dict, Mapping, Type, TypeVar, Union
 
 try:
     from typing_extensions import Literal, Protocol, TypedDict
 except ImportError:
     from typing import Literal, Protocol, TypedDict  # type: ignore
 
+from aiohttp import web
 from aiohttp.web_middlewares import _Handler
 
+
+F = TypeVar("F", bound=Callable[..., Any])
+T = TypeVar("T")
 
 Level = Literal["test", "dev", "staging", "prod"]
 
 Handler = _Handler
-Decorator = Callable[[Handler], Handler]
+ViewType = Type[web.View]
 
 DictStrAny = Dict[str, Any]
 DictStrInt = Dict[str, int]
@@ -33,7 +37,6 @@ MappingStrInt = Mapping[str, int]
 MappingStrStr = Mapping[str, str]
 
 Settings = Union[types.ModuleType, DictStrAny]
-T = TypeVar("T")
 
 
 (Protocol, TypedDict)  # Make flake8 happy

--- a/rororo/openapi/contexts.py
+++ b/rororo/openapi/contexts.py
@@ -27,14 +27,6 @@ def openapi_context(request: web.Request) -> Iterator[OpenAPIContext]:
             with openapi_context(request) as context:
                 ...
 
-    ``OpenAPIContext`` class will contain next attributes:
-
-    - ``request``
-    - ``app``
-    - ``operation``
-    - ``parameters``
-    - ``data``
-
     If using context managers inside of view handlers considered as unwanted,
     there is an other option in
     :func:`rororo.openapi.get_openapi_context` function.

--- a/rororo/openapi/data.py
+++ b/rororo/openapi/data.py
@@ -1,3 +1,12 @@
+"""
+===================
+rororo.openapi.data
+===================
+
+Provide structures for OpenAPI data.
+
+"""
+
 from typing import Any
 
 import attr
@@ -26,6 +35,43 @@ class OpenAPIParameters:
 
 @attr.dataclass(frozen=True, slots=True)
 class OpenAPIContext:
+    """All data associated with current request to OpenAPI handler.
+
+    Contains only valid parameters, security data & request body data.
+    Example bellow illustrates how to work with context data,
+
+    .. code-block:: python
+
+        from rororo import get_openapi_context
+        from rororo.openapi.exceptions import InvalidCredentials
+
+
+        async def create_user(request: web.Request) -> web.Response:
+            context = get_openapi_context(request)
+
+            # Authenticate current user (accessing security data)
+            if not authenticate(api_key=context.security["apiKey"]):
+                raise InvalidCredentials()
+
+            # Add new user (accessing request body data)
+            async with request.config_dict["db"].acquire() as conn:
+                user = await create_user(
+                    conn,
+                    email=context.data["email"],
+                    password=context.data["password"],
+                )
+
+            # Return response due to query string param
+            # (accessing parameters data)
+            if context.parameters.query["login"]:
+                return web.json_response(
+                    request.app.router["login"].url_for()
+                )
+
+            return web.json_response(user.to_api_dict())
+
+    """
+
     #: Request instance
     request: web.Request
 


### PR DESCRIPTION
This commit finishes class based views support for `rororo` as it allows to provide custom operation ID for any view method as,

```python
@operations.register
class UserView(web.View):
    @operations.register("me")
    async def get(self) -> web.Response:
        ...
```

Update Todo-Backend example implementation to cover all possible ways of registering class based views as OpenAPI operation handlers.

Fixes: #45