### PR TITLE
feature(openapi): Get actual handler in openapi middleware

### DIFF
--- a/examples/hobotnica/app.py
+++ b/examples/hobotnica/app.py
@@ -2,6 +2,11 @@ from pathlib import Path
 from typing import List
 
 from aiohttp import web
+from aiohttp_middlewares import (
+    NON_IDEMPOTENT_METHODS,
+    shield_middleware,
+    timeout_middleware,
+)
 
 from rororo import BaseSettings, setup_openapi, setup_settings
 from . import views
@@ -15,7 +20,12 @@ def create_app(
 
     return setup_openapi(
         setup_settings(
-            web.Application(),
+            web.Application(
+                middlewares=(
+                    shield_middleware(methods=NON_IDEMPOTENT_METHODS),
+                    timeout_middleware(29.5),
+                )
+            ),
             settings,
             loggers=("aiohttp", "aiohttp_middlewares", "hobotnica", "rororo"),
             remove_root_handlers=True,

--- a/rororo/openapi/middlewares.py
+++ b/rororo/openapi/middlewares.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 from aiohttp import web
 from aiohttp_middlewares import error_middleware, get_error_response
 from aiohttp_middlewares.annotations import Middleware
@@ -6,6 +8,29 @@ from .constants import REQUEST_CORE_OPERATION_KEY
 from .core_data import find_core_operation
 from .validators import validate_request, validate_response
 from ..annotations import DictStrAny, Handler
+
+
+def get_actual_handler(handler: Handler) -> Handler:
+    """Remove partially applied middlewares from actual handler.
+
+    aiohttp wraps handler into middlewares, so if any middlewares declared in
+    application after ``openapi_middleware`` the handler will look like::
+
+        functools.partial(
+            <function middleware1.<locals>.middleware at 0x111325b80>,
+            handler=functools.partial(
+                <function middleware2.<locals>.middleware at 0x111325ca0>,
+                handler=<function actual_handler at 0x1112aa700>
+            )
+        )
+
+    In that case ``HANDLER_OPENAPI_MAPPING_KEY`` will not be accessed in the
+    partial, which results that handler will not be validated against
+    OpenAPI schema.
+    """
+    if isinstance(handler, partial) and "handler" in handler.keywords:
+        return get_actual_handler(handler.keywords["handler"])
+    return handler
 
 
 def openapi_middleware(
@@ -41,8 +66,11 @@ def openapi_middleware(
         request: web.Request, handler: Handler
     ) -> web.StreamResponse:
         # At first, check that given handler registered as OpenAPI operation
-        # handler
-        core_operation = find_core_operation(request, handler)
+        # handler. For this check remove all partially applied middlewares
+        # from the handler,
+        core_operation = find_core_operation(
+            request, get_actual_handler(handler)
+        )
         if core_operation is None:
             return await get_response(request, handler)
 


### PR DESCRIPTION
If any other middlewares declared after openapi middleware it results that received handler will be an instance of `functools.partial`.

Need to unwrap partial, to try to find openapi mapping in actual handler, not a partial.