### PR TITLE
feature(openapi): Include param name to invalid schema error

### DIFF
--- a/examples/hobotnica/openapi.yaml
+++ b/examples/hobotnica/openapi.yaml
@@ -154,22 +154,21 @@ components:
       in: "header"
       required: true
       schema:
-        type: "string"
-        minLength: 1
+        $ref: "#/components/schemas/NonEmptyString"
 
     RepositoryOwner:
       name: "owner"
       in: "path"
       required: true
       schema:
-        $ref: "#/components/schemas/NonEmptyString"
+        $ref: "#/components/schemas/RepositoryOwner"
 
     RepositoryName:
       name: "name"
       in: "path"
       required: true
       schema:
-        $ref: "#/components/schemas/NonEmptyString"
+        $ref: "#/components/schemas/RepositoryName"
 
   responses:
     DefaultResponse:
@@ -198,6 +197,14 @@ components:
     PositiveInteger:
       type: "integer"
       format: "int64"
+
+    RepositoryOwner:
+      type: "string"
+      minLength: 3
+
+    RepositoryName:
+      type: "string"
+      minLength: 3
 
     RepositoryJob:
       type: "string"

--- a/rororo/openapi/exceptions.py
+++ b/rororo/openapi/exceptions.py
@@ -205,22 +205,19 @@ class ValidationError(OpenAPIError):
         unmarshal_loc: List[PathItem] = None,
     ) -> "ValidationError":
         unmarshal_loc = ["body"] if unmarshal_loc is None else unmarshal_loc
-        parameters = []
-        body = []
+        result = []
 
         for err in errors:
             if isinstance(err, (OpenAPIParameterError, EmptyParameterValue)):
                 details = get_parameter_error_details(err)
                 if details:
-                    parameters.append(details)
+                    result.append(details)
             elif isinstance(err, OpenAPIMediaTypeError):
                 details = get_media_type_error_details(["body"], err)
                 if details:
-                    body.append(details)
+                    result.append(details)
             elif isinstance(err, UnmarshalError):
-                details_list = get_unmarshal_error_details(unmarshal_loc, err)
-                if details_list:
-                    body.extend(details_list)
+                result.extend(get_unmarshal_error_details(unmarshal_loc, err))
             else:
                 logger.debug(
                     "Unhandled request validation error",
@@ -229,7 +226,7 @@ class ValidationError(OpenAPIError):
 
         return cls(
             message="Request parameters or body validation error",
-            errors=parameters + body,
+            errors=result,
         )
 
     @classmethod
@@ -257,9 +254,7 @@ class ValidationError(OpenAPIError):
                 if details:
                     result.append(details)
             elif isinstance(err, UnmarshalError):
-                details_list = get_unmarshal_error_details(["response"], err)
-                if details_list:
-                    result.extend(details_list)
+                result.extend(get_unmarshal_error_details(["response"], err))
             else:
                 logger.debug(
                     "Unhandled response validation error",


### PR DESCRIPTION
`openapi-core==0.13.3` does not include param name in schema errors on unmarshalling values. This results in reduced error locations and as result in bad UX.

For example, previously, when param `name` has invalid value, `rororo` will provide,

```json
{"detail": [{"loc": ["parameters"], "message": "..."}]}
```

But after this fix, `rororo` again will produce,

```json
{"detail": [{"loc": ["parameters", "name"], "message": "..."}]}
```

error message.