### PR TITLE
feat(openapi): Provide basic bad request error

### DIFF
--- a/rororo/openapi/exceptions.py
+++ b/rororo/openapi/exceptions.py
@@ -85,6 +85,13 @@ class OperationError(OpenAPIError):
     default_message = "OpenAPI operation not found"
 
 
+class BadRequest(OpenAPIError):
+    """Bad request basic error."""
+
+    default_message = "Bad request"
+    status = 400
+
+
 class SecurityError(OpenAPIError):
     """Request is not secured, but should."""
 

--- a/tests/test_openapi_exceptions.py
+++ b/tests/test_openapi_exceptions.py
@@ -4,10 +4,15 @@ from openapi_core.schema.media_types.exceptions import OpenAPIMediaTypeError
 from openapi_core.schema.parameters.exceptions import OpenAPIParameterError
 
 from rororo.openapi.exceptions import (
+    BadRequest,
     ObjectDoesNotExist,
     OpenAPIError,
     ValidationError,
 )
+
+
+def test_bad_request():
+    assert str(BadRequest()) == "Bad request"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
In addition to `ObjectDoesNotExist` add basic `BadRequest` error, which is not used by `rororo` internally, but might be useful for external projects.