### PR TITLE
ci: Run build & test jobs in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
         run: "poetry run python -c 'import rororo'"
 
   test:
-    needs: "dev"
     name: "Python ${{ matrix.python-version }}"
 
     strategy:


### PR DESCRIPTION
In reality there is no need to test job wait on build job to succeed. If the build job will fail, test job will cancelled. Which means, running build & test jobs in parallel will speed up CI execution times.