### PR TITLE
perf(openapi): Allow to pass custom schema loader function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,15 @@
 2.0.0 (In Development)
-----------------------
+======================
+
+2.0.0rc1 (In Development)
+-------------------------
+
+Performance:
+~~~~~~~~~~~~
+
+- Use ``yaml.CSafeLoader`` instead of ``yaml.SafeLoader`` when possible. Allow
+  to supply schema loader function to use custom loader, for example
+  ``ujson.loads`` instead of ``json.loads``
 
 2.0.0rc0 (2020-04-27)
 ---------------------
@@ -111,7 +121,7 @@ Build, CI & Style updates:
   - As result entirely remove ``rororo.schemas`` package from the project
 
 1.2.1 (2019-07-08)
-------------------
+==================
 
 - Publish 1.2.1 release
 
@@ -130,7 +140,7 @@ Build, CI & Style updates:
 - chore: Only use poetry for install project deps for tests & lint
 
 1.2.0 (2018-11-01)
-------------------
+==================
 
 - Publish 1.2.0 release
 
@@ -151,17 +161,17 @@ Build, CI & Style updates:
 - Move type annotations to ``rororo.annotations`` module
 
 1.1.1 (2017-10-09)
-------------------
+==================
 
 - Do not attempt to convert empty list to dict for request/response data
 
 1.1.0 (2017-10-09)
-------------------
+==================
 
 - Allow to supply non-dicts in request/response data
 
 1.0.0 (2017-05-14)
-------------------
+==================
 
 - Publish 1.0 release, even proper docs are not ready yet
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,8 @@ Contents
 
    openapi
    openapi_errors
+   openapi_issues
+   openapi_speedups
    settings
    api
    changelog

--- a/docs/openapi_issues.rst
+++ b/docs/openapi_issues.rst
@@ -1,0 +1,45 @@
+==================================
+Known OpenAPI limitations & issues
+==================================
+
+There are some limitations & issues in providing OpenAPI 3 support for
+aiohttp.web applications via ``rororo`` library.
+
+.. important::
+    In case, if your issue not listed below, feel free to open
+    `new issue <https://github.com/playpauseandstop/rororo/issues/new>`_ at
+    Github.
+
+Limitations
+===========
+
+Unsupported Security Schemes
+----------------------------
+
+As of ``2.0.0rc0`` release
+`OAuth2 <https://swagger.io/docs/specification/authentication/oauth2/>`_ &
+`OpenID <https://swagger.io/docs/specification/authentication/openid-connect-discovery/>`_
+security schemes is not supported. And at a moment there is no plans of adding
+support of given security schemes to ``rororo``.
+
+Issues
+======
+
+Path Finder
+-----------
+
+There is known issue that default ``PathFinder`` from ``openapi-core`` library
+matches more paths, then expected and as result return invalid operation, when
+multiple paths in OpenAPI 3 schema matches current request path. Github issue:
+`#226 <https://github.com/p1c2u/openapi-core/issues/226>`_
+
+To fix this ``rororo`` uses its own ``PathFinder`` class, which should work in
+most cases, but sometimes it might produce an error as well. In that case,
+consider rename the path to avoid intersections with other paths in schema.
+
+Nullable Schema
+---------------
+
+Even `#232 <https://github.com/p1c2u/openapi-core/issues/232>`_ is closed, it
+is still not released, which may result in necessity of removing all
+``nullable: true`` properties from the schema.

--- a/docs/openapi_speedups.rst
+++ b/docs/openapi_speedups.rst
@@ -1,0 +1,90 @@
+============================
+Speed up rororo applications
+============================
+
+There are several known ways of improving performance for rororo applications.
+
+[startup] Custom schema loader
+==============================
+
+In most cases you may ignore speeding up startup of aiohttp.web application,
+the place where :func:`rororo.openapi.setup_openapi` called. But, as loading
+schema dict from file is time consuming operation (especially when OpenAPI
+schema file is large or disk, where file is stored, is slow) there are several
+techniques on how to faster load OpenAPI schema.
+
+YAML files
+----------
+
+Ensure that `libyaml <https://pyyaml.org/wiki/LibYAML>`_ is installed in your
+system. After, ``yaml.CSafeLoader`` will be used instead of
+``yaml.SafeLoader``, which might increase load time up to 10 times.
+
+::
+
+    In [1]: import yaml
+
+    In [2]: from api.constants import PROJECT_PATH
+
+    In [3]: schema_path = PROJECT_PATH / "openapi.yaml"
+
+    In [4]: %timeit yaml.load(schema_path.read_text(), Loader=yaml.SafeLoader)
+    164 ms ± 10.1 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
+
+    In [5]: %timeit yaml.load(schema_path.read_text(), Loader=yaml.CSafeLoader)
+    14.6 ms ± 339 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
+
+JSON files
+----------
+
+:func:`rororo.openapi.setup_openapi` allows to pass custom schema loader
+function, as by default, for JSON files, it uses standard :func:`json.loads`,
+which is not the fastest way of loading JSON files into the Python.
+
+Example below illustrates how to use `ujson <https://pypi.org/project/ujson/>`_
+for loading schema from ``openapi.json`` file,
+
+.. code-block:: python
+
+    from pathlib import Path
+
+    import ujson
+    from aiohttp import web
+    from rororo import setup_openapi
+
+    from .views import operations
+
+
+    app = setup_openapi(
+        web.Application(),
+        Path(__file__) / "openapi.json",
+        operations,
+        schema_loader=ujson.loads,
+    )
+
+[runtime] Disable validating responses
+======================================
+
+To satisfy that OpenAPI hander provides proper response ``rororo`` internally
+run ``ResponseValidator.validate(...)`` function.
+
+In most cases this fact is OK as it will ensure that all responses conform
+OpenAPI schema and client will receive expected result. However, it also
+results in extra deserializing / validation calls, which will slow down process
+of getting response from OpenAPI handler.
+
+To "fix" this, there is a possibility to entirely turn off validation of
+responses in ``rororo``,
+
+.. code-block:: python
+
+    app = setup_openapi(
+        web.Application(),
+        Path(__file__) / "openapi.yaml",
+        operations,
+        is_validate_response=False,
+    )
+
+.. danger::
+    Turning off response validation may cause **unexpected** results for
+    application consumers.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -169,8 +169,8 @@ In other words given function is a literally shortcut to,
     settings.apply(...)
     app["settings"] = settings
 
-Step 3. Using the settings
-==========================
+Step 3. Using settings
+======================
 
 In `app.__main__` script
 ------------------------


### PR DESCRIPTION
As well as use `yaml.CSafeLoader` instead of `yaml.SafeLoader` when possible.

Fixes: #61