### PR TITLE
perf(openapi): Allow to cache create schema and spec for test env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
 
     services:
       redis:
-        image: "redis:5.0.8-alpine"
+        image: "redis:6.0.0-alpine"
         ports:
           - "6379/tcp"
         options: "--entrypoint redis-server"
@@ -105,8 +105,7 @@ jobs:
           poetry run python -m openapi_spec_validator tests/openapi.yaml
 
       - name: "Run tests"
-        run: |
-          python -m tox
+        run: "python -m tox"
         env:
           REDIS_URL: "redis://localhost:${{ job.services.redis.ports[6379] }}/0"
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -18,6 +18,8 @@ OpenAPI
 .. automodule:: rororo.openapi.data
 .. autoclass:: rororo.openapi.data.OpenAPIContext
 
+.. autofunction:: rororo.openapi.openapi.read_openapi_schema
+
 Settings
 ========
 

--- a/docs/openapi_speedups.rst
+++ b/docs/openapi_speedups.rst
@@ -88,3 +88,36 @@ responses in ``rororo``,
 .. danger::
     Turning off response validation may cause **unexpected** results for
     application consumers.
+
+[testing] Cache reading schema and spec creation
+================================================
+
+If you have a lot of tests and many of them calling
+:func:`rororo.openapi.setup_openapi` before supplying ``web.Application`` to
+``aiohttp_client`` you might want to speed up things, by caching calls for,
+
+- :func:`rororo.openapi.openapi.read_openapi_schema`
+- :func:`openapi_core.shortcuts.create_spec`
+
+To enable this behaviour use next snippet,
+
+.. code-block:: python
+
+    from pathlib import Path
+
+    from rororo import (
+        BaseSettings,
+        setup_openapi,
+        setup_settings_from_environ,
+    )
+
+
+    app = setup_settings_from_environ(
+        web.Application(), BaseSettings
+    )
+    setup_openapi(
+        app,
+        Path(__file__) / "openapi.yaml",
+        operations,
+        cache_create_schema_and_spec=settings.is_dev,
+    )

--- a/examples/hobotnica/app.py
+++ b/examples/hobotnica/app.py
@@ -33,4 +33,5 @@ def create_app(
         Path(__file__).parent / "openapi.yaml",
         views.operations,
         cors_middleware_kwargs={"allow_all": True},
+        cache_create_schema_and_spec=settings.is_test,
     )

--- a/examples/todobackend/app.py
+++ b/examples/todobackend/app.py
@@ -38,6 +38,8 @@ def create_app(
         cors_middleware_kwargs={
             "origins": ("http://localhost:8081", "http://www.todobackend.com")
         },
+        # Allow caching schema and spec in tests
+        cache_create_schema_and_spec=settings.is_test,
     )
 
     # Enable HTTPS middleware for production

--- a/rororo/openapi/views.py
+++ b/rororo/openapi/views.py
@@ -31,14 +31,16 @@ async def default_error_handler(request: web.Request) -> web.Response:
 async def openapi_schema(request: web.Request) -> web.Response:
     """Dump OpenAPI Schema into specified format."""
     schema_format = request.match_info.get("schema_format")
-    schema = get_openapi_schema(request.app)
+    schema = get_openapi_schema(request.config_dict)
 
     if schema_format == "json":
         return web.json_response(schema)
 
     if schema_format == "yaml":
+        safe_dumper = getattr(yaml, "CSafeDumper", yaml.SafeDumper)
         return web.Response(
-            text=yaml.dump(schema), content_type="application/yaml"
+            text=yaml.dump(schema, Dumper=safe_dumper),
+            content_type="application/yaml",
         )
 
     raise ConfigurationError(

--- a/tests/test_openapi_openapi.py
+++ b/tests/test_openapi_openapi.py
@@ -1,8 +1,17 @@
+from pathlib import Path
+
+import pytest
 from aiohttp import web
 from pyrsistent import pmap
 
-from rororo import OperationTableDef
+from rororo import OperationTableDef, setup_openapi
 from rororo.openapi.constants import HANDLER_OPENAPI_MAPPING_KEY
+
+
+ROOT_PATH = Path(__file__).parent
+
+OPENAPI_JSON_PATH = ROOT_PATH / "openapi.json"
+OPENAPI_YAML_PATH = ROOT_PATH / "openapi.yaml"
 
 
 def test_add_operations():
@@ -27,6 +36,19 @@ def test_add_operations():
     operations += other
     assert operations == all_operations
     assert other != all_operations
+
+
+@pytest.mark.parametrize("schema_path", (OPENAPI_JSON_PATH, OPENAPI_YAML_PATH))
+def test_cache_create_schema_and_spec(schema_path):
+    operations = OperationTableDef()
+    for _ in range(10):
+        setup_openapi(
+            web.Application(),
+            schema_path,
+            operations,
+            server_url="/api/",
+            cache_create_schema_and_spec=True,
+        )
 
 
 def test_ignore_non_http_view_methods():


### PR DESCRIPTION
This is highly experimental feature which is designed to be useful only for test environments, where ``setup_openapi`` called more than once per process flow.