### PR TITLE
fix: Handle all errors on creating OpenAPI spec from schema

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,18 @@
 2.0.0rc3 (In Development)
 -------------------------
 
+Fix:
+~~~~
+
+- Handle all errors on loading OpenAPI schema from files & creating OpenAPI
+  spec, not only ``OpenAPIValidationError`` ones
+
+Docs:
+~~~~~
+
+- Include new *rororo* slogan (aiohttp.web OpenAPI 3 schema first applications)
+  into the docs
+
 Build:
 ~~~~~~
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@
 	lint-only \
 	list-outdated \
 	test \
-	test-only
+	test-only \
+	validate
 
 # Project constants
 PROJECT = rororo
@@ -46,7 +47,7 @@ endif
 
 install: .install
 .install: pyproject.toml poetry.lock
-	$(POETRY) config virtualenvs.in-project true --local
+	$(POETRY) config --local virtualenvs.in-project true
 	$(POETRY) install
 	touch $@
 

--- a/rororo/openapi/openapi.py
+++ b/rororo/openapi/openapi.py
@@ -11,7 +11,6 @@ from aiohttp import hdrs, web
 from aiohttp_middlewares import cors_middleware
 from openapi_core.schema.specs.models import Spec
 from openapi_core.shortcuts import create_spec
-from openapi_spec_validator.exceptions import OpenAPIValidationError
 from pyrsistent import pmap
 from yarl import URL
 
@@ -510,12 +509,12 @@ def setup_openapi(
 
     try:
         oas, spec = create_func(path, schema_loader=schema_loader)
-    except OpenAPIValidationError:
+    except Exception:
         raise ConfigurationError(
             f"Unable to load valid OpenAPI schema in {path}. In most cases "
             "it means that given file doesn't contain valid OpenAPI 3 schema. "
             "To get full details about errors run `openapi-spec-validator "
-            f"{path}`"
+            f"{path.absolute()}`"
         )
 
     # Store schema and spec in application dict

--- a/tests/test_openapi_openapi.py
+++ b/tests/test_openapi_openapi.py
@@ -6,6 +6,7 @@ from pyrsistent import pmap
 
 from rororo import OperationTableDef, setup_openapi
 from rororo.openapi.constants import HANDLER_OPENAPI_MAPPING_KEY
+from rororo.openapi.exceptions import ConfigurationError
 
 
 ROOT_PATH = Path(__file__).parent
@@ -49,6 +50,14 @@ def test_cache_create_schema_and_spec(schema_path):
             server_url="/api/",
             cache_create_schema_and_spec=True,
         )
+
+
+def test_handle_all_create_schema_and_spec_errors(tmp_path):
+    invalid_json = tmp_path / "invalid_openapi.json"
+    invalid_json.write_text('{"openapi": "3.')
+
+    with pytest.raises(ConfigurationError):
+        setup_openapi(web.Application(), invalid_json, OperationTableDef())
 
 
 def test_ignore_non_http_view_methods():


### PR DESCRIPTION
Previously it only handles `OpenAPIValidationError` exceptions, which resulted in bad user experience in case of other errors, such as `JSONDecodeError` (when OpenAPI schema is not valid JSON file).

Fixes: #74