### PR TITLE
feat(openapi): Allow passing `schema` and `spec` keyword args to `setup_openapi`

### DIFF
--- a/docs/openapi.rst
+++ b/docs/openapi.rst
@@ -65,6 +65,14 @@ To start with OpenAPI 3 schema it is recommended to,
 - Browse through `OpenAPI 3 Examples <https://github.com/OAI/OpenAPI-Specification/tree/master/examples/v3.0>`_
 - Try `Swagger Editor <https://editor.swagger.io>`_ online tool
 
+Supply schema & spec instances instead of schema path
+-----------------------------------------------------
+
+To simplify developer experience *rororo* expects only on OpenAPI 3 schema path.
+However it is possible to pass predefined ``schema`` dict and ``spec`` instance
+instead. Consult :func:`rororo.openapi.setup_openapi` to check how to achieve
+that.
+
 Part 2. Map operation with view handler
 =======================================
 

--- a/tests/test_openapi_openapi.py
+++ b/tests/test_openapi_openapi.py
@@ -81,3 +81,8 @@ def test_ignore_non_http_view_methods():
     assert getattr(UserView, HANDLER_OPENAPI_MAPPING_KEY) == pmap(
         {"GET": UserView.get.__qualname__, "PATCH": "update_user"}
     )
+
+
+def test_missed_schema_path_or_schema_and_spec():
+    with pytest.raises(ConfigurationError):
+        setup_openapi(web.Application(), OperationTableDef())


### PR DESCRIPTION
Previously *rororo* relies only on `schema_path` positional argument and does read schema from path and instantiate spec instance inside of `setup_openapi` call.

This commit allows to directly path `schema` and `spec` keyword args to `setup_openapi`, which gives developers wider range of caching / reusing schema & spec for environments, which needs to instantiate `web.Application` (and call `setup_openapi`) a lot.

Fixes: #84