### PR TITLE
chore: 2.0.0 Release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,5 @@ repos:
       - id: "mypy"
         name: "Lint code (mypy)"
         language_version: "python3.8"
-        args: [
-          "--python-executable=.venv/bin/python"
-        ]
+        args: ["--python-executable=.venv/bin/python3"]
         exclude: ^docs/.*$

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,53 @@
 Changelog
 =========
 
-2.0.0 (In Development)
-======================
+2.0.0 (2020-06-29)
+==================
+
+Final **2.0.0** release, which completes reimplementing *rororo* as library
+for implementing aiohttp.web OpenAPI 3 server applications with schema first
+approach.
+
+**Quickstart:**
+
+*rororo* relies on valid OpenAPI 3 schema (both JSON & YAML formats supported).
+Example below illustrates using ``openapi.yaml`` schema file, stored next to
+``app`` module,
+
+.. code-block:: python
+
+    from pathlib import Path
+    from typing import List
+
+    from aiohttp import web
+    from rororo import setup_openapi
+
+    from .views import operations
+
+
+    def create_app(argv: List[str] = None) -> web.Application:
+        return setup_openapi(
+            web.Application(),
+            Path(__file__).parent / "openapi.yaml",
+            operations,
+        )
+
+Then, you need to *register* operation handlers in ``views`` module. Example
+below shows registering handler for *operationId* ``hello_world``,
+
+.. code-block:: python
+
+    from aiohttp import web
+    from rororo import OperationTableDef
+
+
+    @operations.register
+    async def hello_world(request: web.Request) -> web.Response:
+        return web.json_response({"data": "Hello, world!"})
+
+`Documentation <https://rororo.readthedocs.io/en/latest/openapi.html>`_
+provides more information on implementing aiohttp.web OpenAPI 3 server
+applications with schema first approach using *rororo*.
 
 2.0.0rc3 (2020-06-15)
 ---------------------

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -4,6 +4,5 @@ attrs
 openapi-core
 PyYAML
 Sphinx==3.0.4
-sphinx-autobuild
-sphinx-autodoc-typehints
+sphinx_autodoc_typehints
 typing-extensions; python_version <= "3.8"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,7 +7,6 @@
 aiohttp-middlewares==1.1.0  # via -r docs/requirements.in
 aiohttp==3.6.2            # via -r docs/requirements.in, aiohttp-middlewares
 alabaster==0.7.12         # via sphinx
-argh==0.26.2              # via sphinx-autobuild
 async-timeout==3.0.1      # via aiohttp, aiohttp-middlewares
 attrs==19.3.0             # via -r docs/requirements.in, aiohttp, jsonschema, openapi-core
 babel==2.8.0              # via sphinx
@@ -20,26 +19,22 @@ isodate==0.6.0            # via openapi-schema-validator
 jinja2==2.11.2            # via sphinx
 jsonschema==3.2.0         # via openapi-schema-validator, openapi-spec-validator
 lazy-object-proxy==1.5.0  # via openapi-core
-livereload==2.6.2         # via sphinx-autobuild
 markupsafe==1.1.1         # via jinja2
-more-itertools==8.3.0     # via openapi-core
+more-itertools==8.4.0     # via openapi-core
 multidict==4.7.6          # via aiohttp, yarl
 openapi-core==0.13.3      # via -r docs/requirements.in
 openapi-schema-validator==0.1.1  # via openapi-core
 openapi-spec-validator==0.2.8  # via openapi-core
 packaging==20.4           # via sphinx
 parse==1.15.0             # via openapi-core
-pathtools==0.1.2          # via sphinx-autobuild, watchdog
-port_for==0.3.1           # via sphinx-autobuild
 pygments==2.6.1           # via sphinx
 pyparsing==2.4.7          # via packaging
 pyrsistent==0.16.0        # via jsonschema
 pytz==2020.1              # via babel
-pyyaml==5.3.1             # via -r docs/requirements.in, openapi-spec-validator, sphinx-autobuild
+pyyaml==5.3.1             # via -r docs/requirements.in, openapi-spec-validator
 requests==2.23.0          # via sphinx
-six==1.15.0               # via isodate, jsonschema, livereload, openapi-core, openapi-schema-validator, openapi-spec-validator, packaging
+six==1.15.0               # via isodate, jsonschema, openapi-core, openapi-schema-validator, openapi-spec-validator, packaging
 snowballstemmer==2.0.0    # via sphinx
-sphinx-autobuild==0.7.1   # via -r docs/requirements.in
 sphinx-autodoc-typehints==1.10.3  # via -r docs/requirements.in
 sphinx==3.0.4             # via -r docs/requirements.in, sphinx-autodoc-typehints
 sphinxcontrib-applehelp==1.0.2  # via sphinx
@@ -49,10 +44,8 @@ sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 strict-rfc3339==0.7       # via openapi-schema-validator
-tornado==6.0.4            # via livereload, sphinx-autobuild
 typing-extensions==3.7.4.2 ; python_version <= "3.8"  # via -r docs/requirements.in
 urllib3==1.25.9           # via requests
-watchdog==0.10.2          # via sphinx-autobuild
 werkzeug==1.0.1           # via openapi-core
 yarl==1.4.2               # via aiohttp
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,12 @@ show_missing = true
 
 [tool.poetry]
 name = "rororo"
-version = "2.0.0rc3"
-description = "OpenAPI 3 schema support for aiohttp.web applications."
+version = "2.0.0"
+description = "aiohttp.web OpenAPI 3 schema first server applications."
 authors = ["Igor Davydenko <iam@igordavydenko.com>"]
 license = "BSD-3-Clause"
 readme = "README.rst"
-homepage = "https://igordavydenko.com/projects.html#rororo"
+homepage = "https://igordavydenko.com/projects/#rororo"
 repository = "https://github.com/playpauseandstop/rororo"
 documentation = "https://rororo.readthedocs.io/"
 keywords = ["aiohttp", "aiohttp.web", "oas", "openapi", "openapi3", "helpers", "utilities"]

--- a/rororo/__init__.py
+++ b/rororo/__init__.py
@@ -39,4 +39,4 @@ __all__ = (
 
 __author__ = "Igor Davydenko"
 __license__ = "BSD-3-Clause"
-__version__ = "2.0.0rc3"
+__version__ = "2.0.0"

--- a/tests/openapi.json
+++ b/tests/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "rororo",
-    "version": "2.0.0rc3",
+    "version": "2.0.0",
     "contact": {
       "name": "Igor Davydenko (developer)",
       "url": "https://igordavydenko.com",

--- a/tests/openapi.yaml
+++ b/tests/openapi.yaml
@@ -2,7 +2,7 @@ openapi: "3.0.3"
 
 info:
   title: "rororo"
-  version: "2.0.0rc3"
+  version: "2.0.0"
   contact:
     name: "Igor Davydenko (developer)"
     url: "https://igordavydenko.com"


### PR DESCRIPTION
Final **2.0.0** release, which completes reimplementing *rororo* as library for implementing aiohttp.web OpenAPI 3 server applications with schema first approach.

[Docuementation](https://rororo.readthedocs.io/en/stable/openapi.html) provides more information on implementing aiohttp.web OpenAPI 3 server applications with schema first approach using *rororo*.

Fixes: #92