### PR TITLE
ci: Bump github actions to use

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,11 @@ on:
     branches: ["master"]
 
 env:
-  COVERALLS_VERSION: "2.0.0"
+  COVERALLS_VERSION: "2.1.1"
   DEV_PYTHON_VERSION: "3.8"
   POETRY_VERSION: "1.0.9"
-  TOX_GH_ACTIONS_VERSION: "1.2.0"
-  TOX_VERSION: "3.15.2"
+  TOX_GH_ACTIONS_VERSION: "1.3.0"
+  TOX_VERSION: "3.16.1"
   TWINE_VERSION: "3.1.1"
 
 jobs:
@@ -26,7 +26,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
 
     steps:
-      - uses: "actions/checkout@v2.0.0"
+      - uses: "actions/checkout@v2.3.1"
 
       - name: "Install Python"
         uses: "actions/setup-python@v2.0.1"
@@ -61,7 +61,7 @@ jobs:
         options: "--entrypoint redis-server"
 
     steps:
-      - uses: "actions/checkout@v2.0.0"
+      - uses: "actions/checkout@v2.3.1"
 
       - name: "Install Python"
         uses: "actions/setup-python@v2.0.1"
@@ -91,7 +91,7 @@ jobs:
 
       - name: "Run pre-commit"
         if: "matrix.python-version == env.DEV_PYTHON_VERSION"
-        uses: "pre-commit/action@v1.0.1"
+        uses: "pre-commit/action@v2.0.0"
 
       - name: "Validate OpenAPI schemas"
         if: "matrix.python-version == env.DEV_PYTHON_VERSION"
@@ -111,7 +111,7 @@ jobs:
       - name: "Send report to coveralls"
         if: "matrix.python-version == env.DEV_PYTHON_VERSION"
         env:
-          COVERALLS_REPO_TOKEN: "${{ secrets.COVERALLS_REPO_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
           python -m pip install coveralls==${{ env.COVERALLS_VERSION }}
           python -m coveralls
@@ -123,7 +123,7 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
-      - uses: "actions/checkout@v2.0.0"
+      - uses: "actions/checkout@v2.3.1"
 
       - name: "Install Python"
         uses: "actions/setup-python@v2.0.1"
@@ -145,7 +145,7 @@ jobs:
 
       - name: "Publish package"
         if: "github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')"
-        uses: "pypa/gh-action-pypi-publish@v1.1.0"
+        uses: "pypa/gh-action-pypi-publish@v1.3.1"
         with:
           user: "${{ secrets.PYPI_USERNAME }}"
           password: "${{ secrets.PYPI_PASSWORD }}"
@@ -156,7 +156,7 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
-      - uses: "actions/checkout@v2.0.0"
+      - uses: "actions/checkout@v2.3.1"
 
       - name: "Fetch git data"
         run: |
@@ -184,13 +184,13 @@ jobs:
           echo "::set-output name=body::${body}"
 
           prerelease=false
-          if [ ${{ contains(github.event.ref, 'a') }} = true -o ${{ contains(github.event.ref, 'b') }} = true -o ${{ contains(github.event.ref, 'rc') }} = true ]; then
+          if [ -z "${tag_name##*a*}" -o -z "${tag_name##*b*}" -o -z "${tag_name##*rc*}" ]; then
             prerelease=true
           fi
           echo "::set-output name=prerelease::${prerelease}"
 
       - name: "Create new release"
-        uses: "actions/create-release@v1.1.0"
+        uses: "actions/create-release@v1.1.2"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:


### PR DESCRIPTION
As well as,

- Use github token for coveralls
- Fix creating releases from action

Fixes: #95