### PR TITLE
chore: 2.0.2 Release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,19 @@
 Changelog
 =========
 
+2.0.2 (2020-09-04)
+==================
+
+**Features:**
+
+- Depend on ``attrs>=19.1,<21`` to allow use ``attrs==20.1.0`` in dependent
+  projects
+
+**Other:**
+
+- Massive infrastrucutre update: move code to ``src/`` directory, use latest
+  ``pytest`` for tests, better ``Makefile`` targets, etc
+
 2.0.1 (2020-07-21)
 ==================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ show_missing = true
 
 [tool.poetry]
 name = "rororo"
-version = "2.0.2a0"
+version = "2.0.2"
 description = "aiohttp.web OpenAPI 3 schema first server applications."
 authors = ["Igor Davydenko <iam@igordavydenko.com>"]
 license = "BSD-3-Clause"

--- a/src/rororo/__init__.py
+++ b/src/rororo/__init__.py
@@ -39,4 +39,4 @@ __all__ = (
 
 __author__ = "Igor Davydenko"
 __license__ = "BSD-3-Clause"
-__version__ = "2.0.2a0"
+__version__ = "2.0.2"

--- a/tests/openapi.json
+++ b/tests/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "rororo",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "contact": {
       "name": "Igor Davydenko (developer)",
       "url": "https://igordavydenko.com",

--- a/tests/openapi.yaml
+++ b/tests/openapi.yaml
@@ -2,7 +2,7 @@ openapi: "3.0.3"
 
 info:
   title: "rororo"
-  version: "2.0.1"
+  version: "2.0.2"
   contact:
     name: "Igor Davydenko (developer)"
     url: "https://igordavydenko.com"


### PR DESCRIPTION
Features:
---------

- Depend on `attrs>=19.1,<21` to allow install `attrs==20.1.0` in dependent projects

Other:
------

- Massive infrastructure update: move code to `src/` directory, use latest `pytest` for tests, better `Makefile` targets, etc