### PR TITLE
fix(openapi): Proper handling of operations with empty security list

### DIFF
--- a/examples/simulations/app.py
+++ b/examples/simulations/app.py
@@ -8,6 +8,7 @@ from openapi_core.shortcuts import create_spec
 from pyrsistent import thaw
 
 from rororo import get_validated_data, OperationTableDef, setup_openapi
+from rororo.openapi.openapi import get_default_yaml_loader
 from .storage import DEFAULT_STORAGE
 
 
@@ -15,7 +16,10 @@ operations = OperationTableDef()
 
 
 def create_app(argv: List[str] = None) -> web.Application:
-    schema = yaml.load((Path(__file__).parent / "openapi.yaml").read_bytes())
+    schema = yaml.load(
+        (Path(__file__).parent / "openapi.yaml").read_bytes(),
+        Loader=get_default_yaml_loader(),
+    )
 
     app = web.Application()
     app["storage"] = copy.deepcopy(DEFAULT_STORAGE)

--- a/examples/simulations/openapi.yaml
+++ b/examples/simulations/openapi.yaml
@@ -12,6 +12,7 @@ paths:
     post:
       operationId: "create_simulation"
       summary: "Create new simulation"
+      security: []
       requestBody:
         content:
           application/json:
@@ -28,6 +29,7 @@ paths:
     get:
       operationId: "list_simulations"
       summary: "List all available simulations"
+      security: []
       responses:
         "200":
           description: "Simulations list"
@@ -40,6 +42,12 @@ paths:
                 nullable: true
 
 components:
+  securitySchemes:
+    apiKey:
+      type: "apiKey"
+      in: "header"
+      name: "X-API-Key"
+
   schemas:
      Simulation:
       type: "object"
@@ -63,3 +71,6 @@ components:
           type: "integer"
           nullable: true
       required: ["simulation_id", "dataset_id", "model_id"]
+
+security:
+  - apiKey: []

--- a/src/rororo/openapi/openapi.py
+++ b/src/rororo/openapi/openapi.py
@@ -312,6 +312,10 @@ def find_route_prefix(
     )
 
 
+def get_default_yaml_loader() -> SchemaLoader:
+    return cast(SchemaLoader, getattr(yaml, "CSafeLoader", yaml.SafeLoader))
+
+
 def get_route_name(operation_id: str) -> str:
     return operation_id.replace(" ", "-")
 
@@ -340,8 +344,7 @@ def read_openapi_schema(
         if path.suffix == ".json":
             loader = json.loads
         elif path.suffix in {".yml", ".yaml"}:
-            safe_loader = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
-            loader = partial(yaml.load, Loader=safe_loader)
+            loader = partial(yaml.load, Loader=get_default_yaml_loader())
 
     if loader is not None:
         return loader(path.read_bytes())

--- a/src/rororo/openapi/security.py
+++ b/src/rororo/openapi/security.py
@@ -1,4 +1,4 @@
-from typing import cast, Optional, Union
+from typing import cast, Dict, List, Optional, Union
 
 from aiohttp import BasicAuth, hdrs
 from openapi_core.schema.operations.models import Operation
@@ -17,6 +17,8 @@ from ..annotations import MappingStrAny
 
 
 AUTHORIZATION_HEADER = hdrs.AUTHORIZATION
+
+SecurityDict = Dict[str, List[str]]
 
 
 def basic_auth_factory(value: str) -> BasicAuth:
@@ -72,6 +74,14 @@ def get_security_data(
     return value
 
 
+def get_security_list(
+    validator: RequestValidator, operation: Operation
+) -> List[SecurityDict]:
+    if operation.security is not None:
+        return cast(List[SecurityDict], operation.security)
+    return cast(List[SecurityDict], validator.spec.security)
+
+
 def get_security_scheme(
     validator: RequestValidator, scheme_name: str
 ) -> Optional[SecurityScheme]:
@@ -117,7 +127,7 @@ def validate_security(
     their data in request. If some of security items is matched - return it
     as result, if not - raise `SecurityError`.
     """
-    security_list = operation.security or validator.spec.security
+    security_list = get_security_list(validator, operation)
     if not security_list:
         return pmap()
 


### PR DESCRIPTION
If OpenAPI operation setup security as empty list it means that given operation is unsecured even the OpenAPI spec has defined default security schema.

Fix `rororo` security handling to ensure given case. Previously it results in inability of using unsecured operations if OpenAPI schema defines default `security`.

Fixes: #114