### PR TITLE
fix: Proper handling of operations with empty security list

### DIFF
--- a/examples/hobotnica/src/hobotnica/openapi.yaml
+++ b/examples/hobotnica/src/hobotnica/openapi.yaml
@@ -23,11 +23,29 @@ x-default-responses: &default_responses
     $ref: "#/components/responses/DefaultResponse"
 
 paths:
+  "/public/references":
+    get:
+      operationId: "list_all_references"
+      summary: "List references for UI needs"
+      tags: ["public"]
+      security: []
+      responses:
+        <<: *default_responses
+        "200":
+          description: "References list"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AnyObject"
+
   "/repositories":
     get:
       operationId: "list_repositories"
-      tags: ["repositories"]
       summary: "List user repositories registered in Hobotnica"
+      tags: ["repositories"]
+      security:
+        - jwt: []
+        - personalToken: []
       parameters:
         - $ref: "#/components/parameters/GitHubUsername"
       responses:
@@ -40,14 +58,11 @@ paths:
                 type: "array"
                 items:
                   $ref: "#/components/schemas/Repository"
-      security:
-        - jwt: []
-        - personalToken: []
 
     post:
       operationId: "create_repository"
-      tags: ["repositories"]
       summary: "Add new user repository to Hobotnica"
+      tags: ["repositories"]
       parameters:
         - $ref: "#/components/parameters/GitHubUsername"
       requestBody:
@@ -63,14 +78,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Repository"
-      security:
-        - personalToken: []
 
   "/repositories/favorites":
     get:
       operationId: "list_favorites_repositories"
-      tags: ["repositories"]
       summary: "List favorites respositories for logged in user (not implemented yet)"
+      tags: ["repositories"]
       parameters:
         - $ref: "#/components/parameters/GitHubUsername"
         - $ref: "#/components/parameters/Order"
@@ -78,14 +91,14 @@ paths:
         <<: *default_responses
         "204":
           description: "Favorite repositories (not implemented yet)"
-      security:
-        - personalToken: []
 
   "/repositories/{owner}":
     get:
       operationId: "list_owner_repositories"
-      tags: ["repositories"]
       summary: "List repositories owned by user"
+      tags: ["repositories"]
+      security:
+        - basic: []
       parameters:
         - $ref: "#/components/parameters/RepositoryOwner"
       responses:
@@ -98,14 +111,14 @@ paths:
                 type: "array"
                 items:
                   $ref: "#/components/schemas/Repository"
-      security:
-        - basic: []
 
   "/repositories/{owner}/env":
     get:
       operationId: "retrieve_owner_env"
-      tags: ["environment"]
       summary: "Retrieve common environment vars for user"
+      tags: ["environment"]
+      security:
+        - basic: []
       parameters:
         - $ref: "#/components/parameters/RepositoryOwner"
       responses:
@@ -116,15 +129,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AnyObject"
-      security:
-        - basic: []
 
   "/repositories/{owner}/{name}":
     get:
       operationId: "retrieve_repository"
-      tags:
-        - "repositories"
       summary: "Retrieve details of user repository"
+      tags: ["repositories"]
+      security:
+        - jwt: []
+          personalToken: []
       parameters:
         - $ref: "#/components/parameters/GitHubUsername"
         - $ref: "#/components/parameters/RepositoryOwner"
@@ -137,16 +150,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Repository"
-      security:
-        - jwt: []
-          personalToken: []
 
   "/repositories/{owner}/{name}/env":
     get:
       operationId: "retrieve_repository_env"
-      tags:
-        - "environment"
       summary: "Retrieve common env vars for the repository"
+      tags: ["environment"]
       parameters:
         - $ref: "#/components/parameters/GitHubUsername"
         - $ref: "#/components/parameters/RepositoryOwner"
@@ -159,8 +168,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AnyObject"
-      security:
-        - personalToken: []
 
 components:
   parameters:
@@ -309,9 +316,15 @@ components:
       scheme: "bearer"
       bearerFormat: "JWT"
 
+security:
+  - personalToken: []
+
 tags:
   - name: "repositories"
     description: "Repositories endpoints"
 
   - name: "environment"
     description: "Environment endpoints"
+
+  - name: "public"
+    description: "Public endpoints"

--- a/examples/hobotnica/src/hobotnica/views.py
+++ b/examples/hobotnica/src/hobotnica/views.py
@@ -27,6 +27,11 @@ async def create_repository(request: web.Request) -> web.Response:
 
 
 @operations.register
+async def list_all_references(request: web.Request) -> web.Response:
+    return web.json_response({"default_env": {"CI": "1", "HOBOTNICA": "1"}})
+
+
+@operations.register
 @login_required
 async def list_favorites_repositories(request: web.Request) -> web.Response:
     with openapi_context(request) as context:

--- a/src/rororo/openapi/annotations.py
+++ b/src/rororo/openapi/annotations.py
@@ -1,0 +1,4 @@
+from typing import Dict, List
+
+
+SecurityDict = Dict[str, List[str]]

--- a/src/rororo/openapi/security.py
+++ b/src/rororo/openapi/security.py
@@ -1,4 +1,4 @@
-from typing import cast, Dict, List, Optional, Union
+from typing import cast, List, Optional, Union
 
 from aiohttp import BasicAuth, hdrs
 from openapi_core.schema.operations.models import Operation
@@ -12,13 +12,12 @@ from openapi_core.validation.request.datatypes import OpenAPIRequest
 from openapi_core.validation.request.validators import RequestValidator
 from pyrsistent import pmap
 
+from .annotations import SecurityDict
 from .exceptions import BasicSecurityError, SecurityError
 from ..annotations import MappingStrAny
 
 
 AUTHORIZATION_HEADER = hdrs.AUTHORIZATION
-
-SecurityDict = Dict[str, List[str]]
 
 
 def basic_auth_factory(value: str) -> BasicAuth:

--- a/tests/examples/hobotnica/test_hobotnica.py
+++ b/tests/examples/hobotnica/test_hobotnica.py
@@ -9,6 +9,7 @@ from hobotnica.data import (
 from yarl import URL
 
 
+URL_REFERENCES = URL("/api/public/references")
 URL_REPOSITORIES = URL("/api/repositories")
 URL_FAVORITES_REPOSITORIES = URL_REPOSITORIES / "favorites"
 URL_OWNER_REPOSITORIES = URL_REPOSITORIES / GITHUB_USERNAME
@@ -28,6 +29,15 @@ async def test_create_repository_201(aiohttp_client):
         },
     )
     assert response.status == 201
+
+
+async def test_list_all_references(aiohttp_client):
+    client = await aiohttp_client(create_app())
+    response = await client.get(URL_REFERENCES)
+    assert response.status == 200
+    assert await response.json() == {
+        "default_env": {"CI": "1", "HOBOTNICA": "1"}
+    }
 
 
 async def test_list_favorites_repositories_204(aiohttp_client):


### PR DESCRIPTION
If the operation schema does not contain `security` - properly set it to `None` instead of using empty security list from `openapi_core`. This allows properly handle operations with empty security schemas and use global security schema in case of missed operation security.

Fixes: #117