### PR TITLE
fix(openapi): Allow to use parameters within path object

### DIFF
--- a/examples/hobotnica/src/hobotnica/openapi.yaml
+++ b/examples/hobotnica/src/hobotnica/openapi.yaml
@@ -93,14 +93,15 @@ paths:
           description: "Favorite repositories (not implemented yet)"
 
   "/repositories/{owner}":
+    parameters: &repository_owner_parameters
+      - $ref: "#/components/parameters/RepositoryOwner"
+
     get:
       operationId: "list_owner_repositories"
       summary: "List repositories owned by user"
       tags: ["repositories"]
       security:
         - basic: []
-      parameters:
-        - $ref: "#/components/parameters/RepositoryOwner"
       responses:
         <<: *default_responses
         "200":
@@ -113,14 +114,14 @@ paths:
                   $ref: "#/components/schemas/Repository"
 
   "/repositories/{owner}/env":
+    parameters: *repository_owner_parameters
+
     get:
       operationId: "retrieve_owner_env"
       summary: "Retrieve common environment vars for user"
       tags: ["environment"]
       security:
         - basic: []
-      parameters:
-        - $ref: "#/components/parameters/RepositoryOwner"
       responses:
         <<: *default_responses
         "200":
@@ -131,6 +132,10 @@ paths:
                 $ref: "#/components/schemas/AnyObject"
 
   "/repositories/{owner}/{name}":
+    parameters: &repository_owner_name_parameters
+      - $ref: "#/components/parameters/RepositoryOwner"
+      - $ref: "#/components/parameters/RepositoryName"
+
     get:
       operationId: "retrieve_repository"
       summary: "Retrieve details of user repository"
@@ -140,8 +145,6 @@ paths:
           personalToken: []
       parameters:
         - $ref: "#/components/parameters/GitHubUsername"
-        - $ref: "#/components/parameters/RepositoryOwner"
-        - $ref: "#/components/parameters/RepositoryName"
       responses:
         <<: *default_responses
         "200":
@@ -152,14 +155,14 @@ paths:
                 $ref: "#/components/schemas/Repository"
 
   "/repositories/{owner}/{name}/env":
+    parameters: *repository_owner_name_parameters
+
     get:
       operationId: "retrieve_repository_env"
       summary: "Retrieve common env vars for the repository"
       tags: ["environment"]
       parameters:
         - $ref: "#/components/parameters/GitHubUsername"
-        - $ref: "#/components/parameters/RepositoryOwner"
-        - $ref: "#/components/parameters/RepositoryName"
       responses:
         <<: *default_responses
         "200":

--- a/src/rororo/openapi/openapi.py
+++ b/src/rororo/openapi/openapi.py
@@ -339,10 +339,13 @@ def fix_spec_operations(spec: Spec, schema: DictStrAny) -> Spec:
     mapping: Dict[str, Optional[SecurityDict]] = {}
 
     for path_data in schema["paths"].values():
-        for operation_data in path_data.values():
-            mapping[operation_data["operationId"]] = operation_data.get(
-                "security"
-            )
+        for maybe_operation_data in path_data.values():
+            if not isinstance(maybe_operation_data, dict):
+                continue
+
+            mapping[
+                maybe_operation_data["operationId"]
+            ] = maybe_operation_data.get("security")
 
     for path in spec.paths.values():
         for operation in path.operations.values():


### PR DESCRIPTION
Properly understand cases, where `parameters` list defined for whole path as follows,

```yaml
  "/path/{param}":
    parameters:
      - $ref: "#/components/parameters/Param"
```

Fixes: #127