### PR TITLE
feat(openapi): Allow to pass kwargs to validate email func

### DIFF
--- a/src/rororo/openapi/annotations.py
+++ b/src/rororo/openapi/annotations.py
@@ -1,4 +1,14 @@
-from typing import Dict, List
+from typing import Any, Dict, List, Union
+
+from ..annotations import TypedDict
 
 
 SecurityDict = Dict[str, List[str]]
+
+
+class ValidateEmailKwargsDict(TypedDict, total=False):
+    allow_smtputf8: bool
+    allow_empty_local: bool
+    check_deliverability: bool
+    timeout: Union[int, float]
+    dns_resolver: Any

--- a/src/rororo/openapi/constants.py
+++ b/src/rororo/openapi/constants.py
@@ -4,6 +4,9 @@ APP_OPENAPI_SCHEMA_KEY = "rororo_openapi_schema"
 #: Key to store OpenAPI spec within the ``web.Application`` instance
 APP_OPENAPI_SPEC_KEY = "rororo_openapi_spec"
 
+#: Key to store kwargs to pass to ``validate_email`` function
+APP_VALIDATE_EMAIL_KWARGS_KEY = "rororo_validate_email_kwargs"
+
 #: Key to store request method -> operation ID mapping in handler
 HANDLER_OPENAPI_MAPPING_KEY = "__rororo_openapi_mapping__"
 

--- a/src/rororo/openapi/utils.py
+++ b/src/rororo/openapi/utils.py
@@ -6,9 +6,11 @@ from openapi_core.schema.specs.models import Spec
 from openapi_core.validation.request.datatypes import OpenAPIRequest
 from yarl import URL
 
+from .annotations import ValidateEmailKwargsDict
 from .constants import (
     APP_OPENAPI_SCHEMA_KEY,
     APP_OPENAPI_SPEC_KEY,
+    APP_VALIDATE_EMAIL_KWARGS_KEY,
     REQUEST_OPENAPI_CONTEXT_KEY,
 )
 from .data import OpenAPIContext, OpenAPIParameters
@@ -78,6 +80,20 @@ def get_openapi_spec(mixed: Union[web.Application, ChainMapProxy]) -> Spec:
             "Seems like OpenAPI spec not registered to the application. Use "
             '"from rororo import setup_openapi" function to register OpenAPI '
             "schema to your web.Application."
+        )
+
+
+def get_validate_email_kwargs(
+    mixed: Union[web.Application, ChainMapProxy]
+) -> ValidateEmailKwargsDict:
+    try:
+        return cast(
+            ValidateEmailKwargsDict, mixed[APP_VALIDATE_EMAIL_KWARGS_KEY] or {}
+        )
+    except KeyError:
+        raise ConfigurationError(
+            "Seems like kwargs to pass to validate_email function is not "
+            "registered for the given application"
         )
 
 

--- a/src/rororo/openapi/validators.py
+++ b/src/rororo/openapi/validators.py
@@ -4,7 +4,7 @@ from .constants import REQUEST_CORE_REQUEST_KEY, REQUEST_OPENAPI_CONTEXT_KEY
 from .core_data import to_core_openapi_request, to_core_openapi_response
 from .core_validators import validate_core_request, validate_core_response
 from .data import OpenAPIContext
-from .utils import get_openapi_spec
+from .utils import get_openapi_spec, get_validate_email_kwargs
 
 
 async def validate_request(request: web.Request) -> web.Request:
@@ -14,7 +14,9 @@ async def validate_request(request: web.Request) -> web.Request:
     request[REQUEST_CORE_REQUEST_KEY] = core_request
 
     security, parameters, data = validate_core_request(
-        get_openapi_spec(config_dict), core_request
+        get_openapi_spec(config_dict),
+        core_request,
+        validate_email_kwargs=get_validate_email_kwargs(config_dict),
     )
     request[REQUEST_OPENAPI_CONTEXT_KEY] = OpenAPIContext(
         request=request,
@@ -31,9 +33,12 @@ async def validate_request(request: web.Request) -> web.Request:
 def validate_response(
     request: web.Request, response: web.StreamResponse
 ) -> web.StreamResponse:
+    config_dict = request.config_dict
+
     validate_core_response(
-        get_openapi_spec(request.config_dict),
+        get_openapi_spec(config_dict),
         request[REQUEST_CORE_REQUEST_KEY],
         to_core_openapi_response(response),
+        validate_email_kwargs=get_validate_email_kwargs(config_dict),
     )
     return response

--- a/tests/rororo/test_openapi_core_validators.py
+++ b/tests/rororo/test_openapi_core_validators.py
@@ -17,3 +17,12 @@ def test_invalid_value(invalid_value):
 @pytest.mark.parametrize("value", ("email@domain.com", "EmAiL@domain.com"))
 def test_valid_email(value):
     assert EmailFormatter().validate(value) is True
+
+
+def test_valid_email_without_check_deliverability():
+    assert (
+        EmailFormatter(kwargs={"check_deliverability": False}).validate(
+            "email@sub.domain.com"
+        )
+        is True
+    )


### PR DESCRIPTION
*rororo* using [email-validator](https://github.com/JoshData/python-email-validator) library for validating email strings.

In most cases `validate_email(email)` call should be enough, but when not it is now possible to pass `validate_email_kwargs` dict such as follows,

```python
app = setup_openapi(
    web.Application(),
    Path(__file__).parent / "openapi.json",
    operations,
    validate_email_kwargs={"check_deliverability": False},
)
```

Fixes: #133