### PR TITLE
fix: Ensure that Operation ID is an optional value

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     rev: "5.8.0"
     hooks:
       - id: "isort"
-        name: "Format backend code (isort)"
+        name: "Format code (isort)"
         exclude: ^docs/.*$
 
   - repo: "https://github.com/psf/black"

--- a/examples/hobotnica/src/hobotnica/openapi.yaml
+++ b/examples/hobotnica/src/hobotnica/openapi.yaml
@@ -172,6 +172,22 @@ paths:
               schema:
                 $ref: "#/components/schemas/AnyObject"
 
+  "/webhooks/{webhook_uid}":
+    parameters:
+      - $ref: "#/components/parameters/WebhookUID"
+
+    post:
+      tags: ["webhook"]
+      summary: "React on GitHub webhook payload by running registered job (not yet implemented)"
+      responses:
+        <<: *default_responses
+        "200":
+          description: "Build details"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AnyObject"
+
 components:
   parameters:
     GitHubUsername:
@@ -201,6 +217,14 @@ components:
       required: true
       schema:
         $ref: "#/components/schemas/RepositoryName"
+
+    WebhookUID:
+      name: "webhook_uid"
+      in: "path"
+      required: true
+      schema:
+        type: "string"
+        format: "uuid"
 
   responses:
     DefaultResponse:

--- a/src/rororo/openapi/openapi.py
+++ b/src/rororo/openapi/openapi.py
@@ -370,13 +370,18 @@ def fix_spec_operations(spec: Spec, schema: DictStrAny) -> Spec:
             if not isinstance(maybe_operation_data, dict):
                 continue
 
-            mapping[
-                maybe_operation_data["operationId"]
-            ] = maybe_operation_data.get("security")
+            operation_id = maybe_operation_data.get("operationId")
+            if operation_id is None:
+                continue
+
+            mapping[operation_id] = maybe_operation_data.get("security")
 
     for path in spec.paths.values():
         for operation in path.operations.values():
             if operation.security != []:
+                continue
+
+            if operation.operation_id is None:
                 continue
 
             operation.security = mapping[operation.operation_id]


### PR DESCRIPTION
Previously on fixing spec operations *rororo* assumes that operation ID is always present, but due to specification `operationId` should be treat as an optional value and may be missed for some, not yet implemented operations.

This commit fixes the assumption by treating `operationId` as an optional value.