### PR TITLE
chore: 2.3.0 Release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,27 @@
+2.3.0 (2021-10-31)
+==================
+
+Use Python 3.10 as dev version, as well as update minimum supported
+``openapi-core`` version to **0.13.4**.
+
+Also loose a bit ``pyrsistent`` & ``PyYAML`` requirements to allow dependent
+projects use latest versions of given libraries.
+
+**Other:**
+
+- (**deps**) bump actions/cache from 2.1.5 to 2.1.6 (#185)
+- (**deps**) bump peter-evans/create-pull-request from 3.8.2 to 3.10.0 (#186)
+- (**deps**) bump environ-config from 21.1.0 to 21.2.0 (#183)
+- (**deps-dev**) bump pytest-cov from 2.11.1 to 2.12.1 (#187)
+- (**deps**) bump email-validator from 1.1.2 to 1.1.3 (#190)
+- (**deps**) bump pyrsistent from 0.17.3 to 0.18.0 (#189)
+- (**deps**) bump urllib3 from 1.26.4 to 1.26.5 in /docs (#188)
+- (**deps-dev**) bump aioredis from 1.3.1 to 2.0.0 (#192)
+- (**deps**) bump tibdex/github-app-token from 1.3 to 1.4 (#197)
+- Use Python 3.10 as dev version (#194)
+- (**deps**) bump peter-evans/create-pull-request from 3.10.0 to 3.10.1 (#198)
+- (**deps**) bump PyYAML from 5.4.1 to 6.0 (#201)
+
 2.2.2 (2021-05-10)
 ==================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ ignore_missing_imports = true
 
 [tool.poetry]
 name = "rororo"
-version = "2.2.2"
+version = "2.3.0"
 description = "aiohttp.web OpenAPI 3 schema first server applications."
 authors = ["Igor Davydenko <iam@igordavydenko.com>"]
 license = "BSD-3-Clause"

--- a/src/rororo/__init__.py
+++ b/src/rororo/__init__.py
@@ -39,4 +39,4 @@ __all__ = (
 
 __author__ = "Igor Davydenko"
 __license__ = "BSD-3-Clause"
-__version__ = "2.2.2"
+__version__ = "2.3.0"

--- a/tests/rororo/openapi.json
+++ b/tests/rororo/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "rororo",
-    "version": "2.2.2",
+    "version": "2.3.0",
     "contact": {
       "name": "Igor Davydenko (developer)",
       "url": "https://igordavydenko.com",

--- a/tests/rororo/openapi.yaml
+++ b/tests/rororo/openapi.yaml
@@ -2,7 +2,7 @@ openapi: "3.0.3"
 
 info:
   title: "rororo"
-  version: "2.2.2"
+  version: "2.3.0"
   contact:
     name: "Igor Davydenko (developer)"
     url: "https://igordavydenko.com"


### PR DESCRIPTION
Use Python 3.10 as dev version, as well as update minimum supported `openapi-core` version to **0.13.4**.

Also loose a bit `pyrsistent` & `PyYAML` requirements to allow dependent projects use latest versions of given libraries.

Other:
------

- (**deps**) bump actions/cache from 2.1.5 to 2.1.6 (#185)
- (**deps**) bump peter-evans/create-pull-request from 3.8.2 to 3.10.0 (#186)
- (**deps**) bump environ-config from 21.1.0 to 21.2.0 (#183)
- (**deps-dev**) bump pytest-cov from 2.11.1 to 2.12.1 (#187)
- (**deps**) bump email-validator from 1.1.2 to 1.1.3 (#190)
- (**deps**) bump pyrsistent from 0.17.3 to 0.18.0 (#189)
- (**deps**) bump urllib3 from 1.26.4 to 1.26.5 in /docs (#188)
- (**deps-dev**) bump aioredis from 1.3.1 to 2.0.0 (#192)
- (**deps**) bump tibdex/github-app-token from 1.3 to 1.4 (#197)
- Use Python 3.10 as dev version (#194)
- (**deps**) bump peter-evans/create-pull-request from 3.10.0 to 3.10.1 (#198)
- (**deps**) bump PyYAML from 5.4.1 to 6.0 (#201)