### PR TITLE
Update to latest openapi-core

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -163,6 +163,14 @@ optional = false
 python-versions = ">=3.6, <3.7"
 
 [[package]]
+name = "dictpath"
+version = "0.1.3"
+description = "Object-oriented dictionary paths"
+category = "main"
+optional = false
+python-versions = ">= 2.7, != 3.0.*, != 3.1.*, != 3.2.*, != 3.3.*, != 3.4.*"
+
+[[package]]
 name = "dnspython"
 version = "2.1.0"
 description = "DNS toolkit"
@@ -309,14 +317,6 @@ format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validat
 format_nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "uri-template", "webcolors (>=1.11)"]
 
 [[package]]
-name = "lazy-object-proxy"
-version = "1.6.0"
-description = "A fast and thorough lazy object proxy."
-category = "main"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
-
-[[package]]
 name = "more-itertools"
 version = "8.10.0"
 description = "More routines for operating on iterables, beyond itertools"
@@ -360,27 +360,34 @@ python-versions = "*"
 
 [[package]]
 name = "openapi-core"
-version = "0.13.6"
-description = ""
+version = "0.14.2"
+description = "client-side and server-side support for the OpenAPI Specification v3"
 category = "main"
 optional = false
-python-versions = ">= 2.7, != 3.0.*, != 3.1.*, != 3.2.*, != 3.3.*, != 3.4.*"
+python-versions = "^3.6.2"
+develop = false
 
 [package.dependencies]
-attrs = "*"
+dataclasses = {version = "*", markers = "python_version >= \"3.6\" and python_version < \"3.7\""}
+dictpath = "*"
 isodate = "*"
-lazy-object-proxy = "*"
 more-itertools = "*"
 openapi-schema-validator = "*"
 openapi-spec-validator = "*"
 parse = "*"
-six = "*"
 werkzeug = "*"
 
 [package.extras]
-django = ["django (>=2.2)"]
+django = ["django (>=3.0)"]
+falcon = ["falcon (>=3.0)"]
 flask = ["flask"]
 requests = ["requests"]
+
+[package.source]
+type = "git"
+url = "https://github.com/p1c2u/openapi-core.git"
+reference = "master"
+resolved_reference = "fda9fbd3bc1c0879818e00445e1ad0731f80b065"
 
 [[package]]
 name = "openapi-schema-validator"
@@ -633,8 +640,8 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.6"
-content-hash = "d9eebf2a9f66ae6c85c072664820cc0103658f745f388cd89a2af33a2fb56f6b"
+python-versions = "^3.6.2"
+content-hash = "e3fdc285d4ff24ca79c09649652000ca635b9264c322c61a82ed034f06178100"
 
 [metadata.files]
 aiohttp = [
@@ -806,6 +813,11 @@ coverage = [
 dataclasses = [
     {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
     {file = "dataclasses-0.8.tar.gz", hash = "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"},
+]
+dictpath = [
+    {file = "dictpath-0.1.3-py2-none-any.whl", hash = "sha256:225248e3c1e7c375495d5da5c390cbf3490f56ee42c151df733e5b2df6b521b5"},
+    {file = "dictpath-0.1.3-py3-none-any.whl", hash = "sha256:d5212361d1fb93909cff715f6e0404e17752cf7a48df3e140639e529a027c437"},
+    {file = "dictpath-0.1.3.tar.gz", hash = "sha256:751cde3b76b176d25f961b90c423a11a4d5ede9bd09ab0d64a85abb738c190d8"},
 ]
 dnspython = [
     {file = "dnspython-2.1.0-py3-none-any.whl", hash = "sha256:95d12f6ef0317118d2a1a6fc49aac65ffec7eb8087474158f42f26a639135216"},
@@ -988,30 +1000,6 @@ jsonschema = [
     {file = "jsonschema-4.0.0-py3-none-any.whl", hash = "sha256:c773028c649441ab980015b5b622f4cd5134cf563daaf0235ca4b73cc3734f20"},
     {file = "jsonschema-4.0.0.tar.gz", hash = "sha256:bc51325b929171791c42ebc1c70b9713eb134d3bb8ebd5474c8b659b15be6d86"},
 ]
-lazy-object-proxy = [
-    {file = "lazy-object-proxy-1.6.0.tar.gz", hash = "sha256:489000d368377571c6f982fba6497f2aa13c6d1facc40660963da62f5c379726"},
-    {file = "lazy_object_proxy-1.6.0-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:c6938967f8528b3668622a9ed3b31d145fab161a32f5891ea7b84f6b790be05b"},
-    {file = "lazy_object_proxy-1.6.0-cp27-cp27m-win32.whl", hash = "sha256:ebfd274dcd5133e0afae738e6d9da4323c3eb021b3e13052d8cbd0e457b1256e"},
-    {file = "lazy_object_proxy-1.6.0-cp27-cp27m-win_amd64.whl", hash = "sha256:ed361bb83436f117f9917d282a456f9e5009ea12fd6de8742d1a4752c3017e93"},
-    {file = "lazy_object_proxy-1.6.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:d900d949b707778696fdf01036f58c9876a0d8bfe116e8d220cfd4b15f14e741"},
-    {file = "lazy_object_proxy-1.6.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5743a5ab42ae40caa8421b320ebf3a998f89c85cdc8376d6b2e00bd12bd1b587"},
-    {file = "lazy_object_proxy-1.6.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:bf34e368e8dd976423396555078def5cfc3039ebc6fc06d1ae2c5a65eebbcde4"},
-    {file = "lazy_object_proxy-1.6.0-cp36-cp36m-win32.whl", hash = "sha256:b579f8acbf2bdd9ea200b1d5dea36abd93cabf56cf626ab9c744a432e15c815f"},
-    {file = "lazy_object_proxy-1.6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:4f60460e9f1eb632584c9685bccea152f4ac2130e299784dbaf9fae9f49891b3"},
-    {file = "lazy_object_proxy-1.6.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d7124f52f3bd259f510651450e18e0fd081ed82f3c08541dffc7b94b883aa981"},
-    {file = "lazy_object_proxy-1.6.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:22ddd618cefe54305df49e4c069fa65715be4ad0e78e8d252a33debf00f6ede2"},
-    {file = "lazy_object_proxy-1.6.0-cp37-cp37m-win32.whl", hash = "sha256:9d397bf41caad3f489e10774667310d73cb9c4258e9aed94b9ec734b34b495fd"},
-    {file = "lazy_object_proxy-1.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:24a5045889cc2729033b3e604d496c2b6f588c754f7a62027ad4437a7ecc4837"},
-    {file = "lazy_object_proxy-1.6.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:17e0967ba374fc24141738c69736da90e94419338fd4c7c7bef01ee26b339653"},
-    {file = "lazy_object_proxy-1.6.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:410283732af311b51b837894fa2f24f2c0039aa7f220135192b38fcc42bd43d3"},
-    {file = "lazy_object_proxy-1.6.0-cp38-cp38-win32.whl", hash = "sha256:85fb7608121fd5621cc4377a8961d0b32ccf84a7285b4f1d21988b2eae2868e8"},
-    {file = "lazy_object_proxy-1.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:d1c2676e3d840852a2de7c7d5d76407c772927addff8d742b9808fe0afccebdf"},
-    {file = "lazy_object_proxy-1.6.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:b865b01a2e7f96db0c5d12cfea590f98d8c5ba64ad222300d93ce6ff9138bcad"},
-    {file = "lazy_object_proxy-1.6.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:4732c765372bd78a2d6b2150a6e99d00a78ec963375f236979c0626b97ed8e43"},
-    {file = "lazy_object_proxy-1.6.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:9698110e36e2df951c7c36b6729e96429c9c32b3331989ef19976592c5f3c77a"},
-    {file = "lazy_object_proxy-1.6.0-cp39-cp39-win32.whl", hash = "sha256:1fee665d2638491f4d6e55bd483e15ef21f6c8c2095f235fef72601021e64f61"},
-    {file = "lazy_object_proxy-1.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:f5144c75445ae3ca2057faac03fda5a902eff196702b0a24daf1d6ce0650514b"},
-]
 more-itertools = [
     {file = "more-itertools-8.10.0.tar.gz", hash = "sha256:1debcabeb1df793814859d64a81ad7cb10504c24349368ccf214c664c474f41f"},
     {file = "more_itertools-8.10.0-py3-none-any.whl", hash = "sha256:56ddac45541718ba332db05f464bebfb0768110111affd27f66e0051f276fa43"},
@@ -1116,11 +1104,7 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
-openapi-core = [
-    {file = "openapi-core-0.13.6.tar.gz", hash = "sha256:b291e4cf40486a18d698c75a96b616f8d19d9e6f24367c79e061c8f52efc8603"},
-    {file = "openapi_core-0.13.6-py2-none-any.whl", hash = "sha256:ef4a6d4dfe607c14e8fc3d0da0bf1035f054894ad75454674da1b4070caeebd1"},
-    {file = "openapi_core-0.13.6-py3-none-any.whl", hash = "sha256:e8e3e7fec220614ede1ee1bc2e80d74bc47727c6e108e8212dcd97733cf31f26"},
-]
+openapi-core = []
 openapi-schema-validator = [
     {file = "openapi-schema-validator-0.1.5.tar.gz", hash = "sha256:a4b2712020284cee880b4c55faa513fbc2f8f07f365deda6098f8ab943c9f0df"},
     {file = "openapi_schema_validator-0.1.5-py2-none-any.whl", hash = "sha256:215b516d0942f4e8e2446cf3f7d4ff2ed71d102ebddcc30526d8a3f706ab1df6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.6.2"
 aiohttp = "^3.7.0"
 aiohttp-middlewares = "^1.2.0"
 attrs = ">=19.2.0,<22"
@@ -118,7 +118,7 @@ contextvars = {python = "<3.7", version = "^2.4"}
 email-validator = "^1.0.5"
 environ-config = ">=20.1,<22.0"
 isodate = "^0.6.0"
-openapi-core = ">=0.13.4,<0.13.7"
+openapi-core = {git = "https://github.com/p1c2u/openapi-core.git"}
 pyrsistent = ">=0.16,<0.19"
 PyYAML = ">=5.1,<7.0"
 typing-extensions = {python = "<3.8", version = ">=3.7,<5.0"}

--- a/src/rororo/openapi/core_validators.py
+++ b/src/rororo/openapi/core_validators.py
@@ -1,38 +1,14 @@
 from collections import deque
-from functools import partial
-from typing import Any, cast, Dict, Iterator, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 import pyrsistent
 from email_validator import EmailNotValidError, validate_email
-from isodate import parse_datetime
 from jsonschema.exceptions import FormatError
-from more_itertools import peekable
 from openapi_core.casting.schemas.exceptions import CastError as CoreCastError
 from openapi_core.exceptions import OpenAPIError as CoreOpenAPIError
-from openapi_core.schema.operations.models import Operation
-from openapi_core.schema.parameters.models import Parameter
-from openapi_core.schema.paths.models import Path
-from openapi_core.schema.schemas.enums import SchemaFormat, SchemaType
-from openapi_core.schema.schemas.types import NoValue
-from openapi_core.schema.servers.models import Server
-from openapi_core.schema.specs.models import Spec
-from openapi_core.templating.datatypes import TemplateResult
-from openapi_core.templating.paths.exceptions import (
-    OperationNotFound,
-    PathNotFound,
-    ServerNotFound,
-)
-from openapi_core.templating.paths.finders import PathFinder as CorePathFinder
-from openapi_core.unmarshalling.schemas.enums import UnmarshalContext
+from openapi_core.spec.paths import SpecPath
 from openapi_core.unmarshalling.schemas.exceptions import InvalidSchemaValue
-from openapi_core.unmarshalling.schemas.factories import (
-    SchemaUnmarshallersFactory as CoreSchemaUnmarshallersFactory,
-)
 from openapi_core.unmarshalling.schemas.formatters import Formatter
-from openapi_core.unmarshalling.schemas.unmarshallers import (
-    ArrayUnmarshaller as CoreArrayUnmarshaller,
-    ObjectUnmarshaller as CoreObjectUnmarshaller,
-)
 from openapi_core.validation.request.datatypes import (
     OpenAPIRequest,
     RequestParameters,
@@ -47,34 +23,13 @@ from openapi_core.validation.response.validators import (
 from openapi_core.validation.validators import (
     BaseValidator as CoreBaseValidator,
 )
-from openapi_schema_validator._format import oas30_format_checker
 
 from ..annotations import MappingStrAny
 from .annotations import ValidateEmailKwargsDict
 from .data import OpenAPIParameters, to_openapi_parameters
 from .exceptions import CastError, ValidationError
-from .security import validate_security
+from .security import SecurityProviderFactory
 from .utils import get_base_url
-
-
-DATE_TIME_FORMATTER = Formatter.from_callables(
-    partial(oas30_format_checker.check, format="date-time"),
-    parse_datetime,
-)
-PathTuple = Tuple[Path, Operation, Server, TemplateResult, TemplateResult]
-
-
-class ArrayUnmarshaller(CoreArrayUnmarshaller):
-    """Custom array unmarshaller to support nullable arrays.
-
-    To be removed after ``openapi-core`` fixed an issue of supporting nullable
-    arrays: https://github.com/p1c2u/openapi-core/issues/251
-    """
-
-    def __call__(self, value: Any = NoValue) -> Optional[List[Any]]:
-        if value is None and self.schema.nullable:
-            return None
-        return cast(List[Any], super().__call__(value))
 
 
 class EmailFormatter(Formatter):
@@ -97,171 +52,51 @@ class EmailFormatter(Formatter):
         return True
 
 
-class ObjectUnmarshaller(CoreObjectUnmarshaller):
-    """Custom object unmarshaller to support nullable objects.
-
-    To be removed after ``openapi-core`` fixed an issue of` supporting nullable
-    objects: https://github.com/p1c2u/openapi-core/issues/232
-    """
-
-    def __call__(self, value: Any = NoValue) -> Optional[Dict[Any, Any]]:
-        if value is None and self.schema.nullable:
-            return None
-        return cast(Dict[Any, Any], super().__call__(value))
-
-
-class PathFinder(CorePathFinder):
-    """Custom path finder to fix issue with finding paths with vars.
-
-    Temporary fix for https://github.com/p1c2u/openapi-core/issues/226, to be
-    removed from *rororo* after next ``openapi-core`` version released with
-    proper fix for the issue.
-    """
-
-    def find(self, request: OpenAPIRequest) -> PathTuple:
-        """Better finder for request path.
-
-        Instead of returning first possible result from
-        ``self._get_servers_iter(...)`` call, attempt to ensure that
-        ``request.full_url_pattern`` ends with ``path.name``.
-        """
-        paths_iter_peek = peekable(
-            self._get_paths_iter(request.full_url_pattern)
-        )
-        if not paths_iter_peek:
-            raise PathNotFound(request.full_url_pattern)
-
-        operations_iter_peek = peekable(
-            self._get_operations_iter(request.method, paths_iter_peek)
-        )
-        if not operations_iter_peek:
-            raise OperationNotFound(request.full_url_pattern, request.method)
-
-        servers_iter: Iterator[PathTuple] = self._get_servers_iter(
-            request.full_url_pattern, operations_iter_peek
-        )
-        for server in servers_iter:
-            path = server[0]
-            if request.full_url_pattern.endswith(path.name):
-                return server
-
-        raise ServerNotFound(request.full_url_pattern)
-
-
-class SchemaUnmarshallersFactory(CoreSchemaUnmarshallersFactory):
-    """
-    Custom schema unmarshallers factory to deal with tz aware date time
-    strings.
-
-    Temporary fix to https://github.com/p1c2u/openapi-core/issues/235, to be
-    removed from *rororo* after next ``openapi-core`` release.
-    """
-
-    COMPLEX_UNMARSHALLERS = {
-        **CoreSchemaUnmarshallersFactory.COMPLEX_UNMARSHALLERS,
-        SchemaType.ARRAY: ArrayUnmarshaller,
-        SchemaType.OBJECT: ObjectUnmarshaller,
-    }
-
-    def get_formatter(
-        self,
-        default_formatters: Dict[str, Formatter],
-        type_format: str = None,
-    ) -> Formatter:
-        if type_format == SchemaFormat.DATETIME.value:
-            return DATE_TIME_FORMATTER
-        return super().get_formatter(default_formatters, type_format)
-
-
 class BaseValidator(CoreBaseValidator):
-    """Custom base validator to deal with tz aware date time strings.
-
-    To be removed from *rororo* after next ``openapi-core`` version release.
-    """
-
-    def _cast(self, param_or_media_type: Any, value: Any) -> Any:
+    def _get_param_or_header_value(
+        self, param_or_header: Any, location, name=None
+    ):
         try:
-            return super()._cast(param_or_media_type, value)
-        except CoreCastError as err:
-            # Pass param or media type name to cast error
-            raise CastError(
-                name=param_or_media_type.name, value=err.value, type=err.type
+            return super()._get_param_or_header_value(
+                param_or_header, location, name
             )
-
-    def _find_path(self, request: OpenAPIRequest) -> PathTuple:
-        return PathFinder(self.spec, base_url=self.base_url).find(request)
-
-    def _unmarshal(
-        self, param_or_media_type: Any, value: Any, context: UnmarshalContext
-    ) -> Any:
-        """Use custom unmarshallers factory for unmarsahlling data."""
-        if not param_or_media_type.schema:
-            return value
-
-        unmarshallers_factory = SchemaUnmarshallersFactory(
-            self.spec._resolver,
-            self.custom_formatters,
-            context=context,
-        )
-        unmarshaller = unmarshallers_factory.create(param_or_media_type.schema)
-
-        try:
-            return unmarshaller(value)
+        except CoreCastError as err:
+            raise CastError(
+                name=param_or_header["name"],
+                value=err.value,
+                type=err.type,
+            )
         except InvalidSchemaValue as err:
-            # Modify invalid schema validation errors to include parameter name
-            if isinstance(param_or_media_type, Parameter):
-                param_name = param_or_media_type.name
-
+            if isinstance(param_or_header, SpecPath):
                 for schema_error in err.schema_errors:
                     schema_error.path = schema_error.relative_path = deque(
-                        [param_name]
+                        [param_or_header["name"]]
                     )
-
             raise err
 
 
 class RequestValidator(BaseValidator, CoreRequestValidator):
+    @property
+    def security_provider_factory(self):
+        return SecurityProviderFactory()
+
     def _get_parameters(
-        self, request: OpenAPIRequest, params: MappingStrAny
+        self, request: OpenAPIRequest, path, operation
     ) -> Tuple[RequestParameters, List[CoreOpenAPIError]]:
         """
         Distinct parameters errors from body errors to supply proper validation
         error response.
         """
-        parameters, errors = super()._get_parameters(request, params)
+        parameters, errors = super()._get_parameters(request, path, operation)
         if errors:
             raise ValidationError.from_request_errors(
                 errors, base_loc=["parameters"]
             )
         return parameters, errors
 
-    def _get_security(
-        self, request: OpenAPIRequest, operation: Operation
-    ) -> MappingStrAny:
-        """
-        Custom logic for validating request security, which support handling
-        JWT tokens without decoding them from ``base64`` (as needed for
-        basic authorization).
-
-        Consider to remove from *rororo* after next ``openapi-core`` release.
-        """
-        return validate_security(self, request, operation)
-
-    def _unmarshal(  # type: ignore
-        self, param_or_media_type: Any, value: Any
-    ) -> Any:
-        return super()._unmarshal(
-            param_or_media_type, value, UnmarshalContext.REQUEST
-        )
-
 
 class ResponseValidator(BaseValidator, CoreResponseValidator):
-    def _unmarshal(  # type: ignore
-        self, param_or_media_type: Any, value: Any
-    ) -> Any:
-        return super()._unmarshal(
-            param_or_media_type, value, UnmarshalContext.RESPONSE
-        )
+    ...
 
 
 def get_custom_formatters(
@@ -271,7 +106,7 @@ def get_custom_formatters(
 
 
 def validate_core_request(
-    spec: Spec,
+    spec: SpecPath,
     core_request: OpenAPIRequest,
     *,
     validate_email_kwargs: ValidateEmailKwargsDict = None,
@@ -302,7 +137,7 @@ def validate_core_request(
 
 
 def validate_core_response(
-    spec: Spec,
+    spec: SpecPath,
     core_request: OpenAPIRequest,
     core_response: OpenAPIResponse,
     *,

--- a/src/rororo/openapi/security.py
+++ b/src/rororo/openapi/security.py
@@ -1,159 +1,68 @@
-from typing import cast, List, Optional, Union
+import base64
+import binascii
+from typing import Union
 
 from aiohttp import BasicAuth, hdrs
-from openapi_core.schema.operations.models import Operation
-from openapi_core.schema.security_schemes.enums import (
-    HttpAuthScheme,
-    SecuritySchemeType,
-)
-from openapi_core.schema.security_schemes.models import SecurityScheme
 from openapi_core.security.exceptions import SecurityError as CoreSecurityError
+from openapi_core.security.factories import (
+    SecurityProviderFactory as CoreSecurityProviderFactory,
+)
+from openapi_core.security.providers import (
+    ApiKeyProvider as CoreApiKeyProvider,
+    HttpProvider as CoreHttpProvider,
+)
 from openapi_core.validation.request.datatypes import OpenAPIRequest
-from openapi_core.validation.request.validators import RequestValidator
-from pyrsistent import pmap
-
-from ..annotations import MappingStrAny
-from .annotations import SecurityDict
-from .exceptions import BasicSecurityError, SecurityError
 
 
-AUTHORIZATION_HEADER = hdrs.AUTHORIZATION
+class ApiKeyProvider(CoreApiKeyProvider):
+    def __call__(self, request: OpenAPIRequest) -> str:
+        name = self.scheme["name"]
+        location = self.scheme["in"]
+        source = getattr(request.parameters, location)
+        for header_name, header_value in source:
+            if name == header_name:
+                return header_value
+        else:
+            raise CoreSecurityError("Missing api key parameter.")
 
 
-def basic_auth_factory(value: str) -> BasicAuth:
-    # Workaround for ``openapi-core==0.13.3``
-    if ":" in value:
-        return BasicAuth(*(item.strip() for item in value.split(":", 1)))
-    # In ``openapi-core==0.13.4`` parsing security schemas changed, now the
-    # value for basic auth is base64 encoded string
-    return BasicAuth.decode(f"Basic {value}")
+class HttpProvider(CoreHttpProvider):
+    def __call__(self, request: OpenAPIRequest) -> Union[BasicAuth, str]:
+        for header_name, header_value in request.parameters.header:
+            if header_name == hdrs.AUTHORIZATION:
+                try:
+                    auth_type, encoded_credentials = header_value.split(" ", 1)
+                except ValueError:
+                    raise CoreSecurityError(
+                        "Could not parse authorization header."
+                    )
+                scheme = self.scheme["scheme"]
+                if auth_type.lower() != scheme:
+                    raise CoreSecurityError(
+                        f"Unknown authorization method {auth_type}"
+                    )
+                if self.scheme["scheme"] == "basic":
+                    try:
+                        decoded = base64.b64decode(
+                            encoded_credentials.encode("ascii"), validate=True
+                        ).decode("latin1")
+                    except binascii.Error:
+                        raise CoreSecurityError("Invalid base64 encoding.")
+
+                    try:
+                        username, password = decoded.split(":", 1)
+                    except ValueError:
+                        raise CoreSecurityError("Invalid credentials.")
+                    return BasicAuth(username, password)
+                else:
+                    return encoded_credentials
+        else:
+            raise CoreSecurityError("Missing authorization header.")
 
 
-def get_jwt_security_data(request: OpenAPIRequest) -> Optional[str]:
-    """Get JWT bearer security data.
-
-    At a moment, openapi-core attempts to decode JWT header using same rules
-    as for basic auth, which might return unexpected results.
-    """
-    header: Optional[str] = request.parameters.header.get(AUTHORIZATION_HEADER)
-
-    # Header does not exist
-    if header is None:
-        return None
-
-    try:
-        maybe_bearer, value = header.split(" ", 1)
-    except ValueError:
-        return None
-
-    if maybe_bearer.lower() != "bearer":
-        return None
-
-    return value
-
-
-def get_security_data(
-    validator: RequestValidator, request: OpenAPIRequest, scheme_name: str
-) -> Optional[Union[BasicAuth, str]]:
-    """Get security data from request.
-
-    Currently supported getting API Key & HTTP security data. OAuth & OpenID
-    data not supported yet.
-    """
-    if is_jwt_bearer_security_scheme(validator, scheme_name):
-        return get_jwt_security_data(request)
-
-    try:
-        value: str = validator._get_security_value(scheme_name, request)
-    except CoreSecurityError:
-        return None
-
-    if is_basic_auth_security_scheme(validator, scheme_name):
-        return basic_auth_factory(value)
-    return value
-
-
-def get_security_list(
-    validator: RequestValidator, operation: Operation
-) -> List[SecurityDict]:
-    if operation.security is not None:
-        return cast(List[SecurityDict], operation.security)
-    return cast(List[SecurityDict], validator.spec.security)
-
-
-def get_security_scheme(
-    validator: RequestValidator, scheme_name: str
-) -> Optional[SecurityScheme]:
-    return validator.spec.components.security_schemes.get(scheme_name)
-
-
-def is_basic_auth_security_scheme(
-    validator: RequestValidator, scheme_name: str
-) -> bool:
-    scheme = get_security_scheme(validator, scheme_name)
-    if scheme is None:
-        return False
-    return cast(
-        bool,
-        scheme.type == SecuritySchemeType.HTTP
-        and scheme.scheme == HttpAuthScheme.BASIC,
-    )
-
-
-def is_jwt_bearer_security_scheme(
-    validator: RequestValidator, scheme_name: str
-) -> bool:
-    scheme = get_security_scheme(validator, scheme_name)
-    if scheme is None:
-        return False
-    return cast(
-        bool,
-        scheme.type == SecuritySchemeType.HTTP
-        and scheme.scheme == HttpAuthScheme.BEARER,
-    )
-
-
-def validate_security(
-    validator: RequestValidator, request: OpenAPIRequest, operation: Operation
-) -> MappingStrAny:
-    """Validate security data for the request if any.
-
-    First, check whether operation is secured or there is global security
-    definitions. If not and current operation is not secured - return empty
-    :class:`pyrsistent.PMap`.
-
-    If operation secured, go through all security items and attempt to match
-    their data in request. If some of security items is matched - return it
-    as result, if not - raise `SecurityError`.
-    """
-    security_list = get_security_list(validator, operation)
-    if not security_list:
-        return pmap()
-
-    # If operation "secured" with an empty object it means the whole security
-    # rules are optional. However to not return empty security details it is
-    # needed to move given security scheme to the bottom
-    has_empty_security = {} in security_list
-    if has_empty_security:
-        security_list.remove({})
-        security_list.append({})
-
-    for item in security_list:
-        data = {
-            key: get_security_data(validator, request, key) for key in item
-        }
-        if all(value for value in data.values()):
-            return pmap(data)
-
-    # To supply proper security error need to check how many security schemas
-    # should be applied for given operation
-    #
-    # If there is only one security schema with one security schema item and
-    # it is a HTTP basic - raise BasicSecurityError (401 Unauthenticated). In
-    # all other cases - raise a SecurityError (403 Access Denied)
-    if len(security_list) == 1 and len(security_list[0]) == 1:
-        scheme_name = list(security_list[0].keys())[0]
-        if is_basic_auth_security_scheme(validator, scheme_name):
-            raise BasicSecurityError()
-
-    raise SecurityError()
+class SecurityProviderFactory(CoreSecurityProviderFactory):
+    PROVIDERS = {
+        **CoreSecurityProviderFactory.PROVIDERS,
+        "apiKey": ApiKeyProvider,
+        "http": HttpProvider,
+    }

--- a/src/rororo/openapi/utils.py
+++ b/src/rororo/openapi/utils.py
@@ -2,7 +2,7 @@ from typing import Any, cast, Optional, Union
 
 from aiohttp import web
 from aiohttp.helpers import ChainMapProxy
-from openapi_core.schema.specs.models import Spec
+from openapi_core.spec.paths import SpecPath
 from openapi_core.validation.request.datatypes import OpenAPIRequest
 from yarl import URL
 
@@ -67,7 +67,7 @@ def get_openapi_schema(
         )
 
 
-def get_openapi_spec(mixed: Union[web.Application, ChainMapProxy]) -> Spec:
+def get_openapi_spec(mixed: Union[web.Application, ChainMapProxy]) -> SpecPath:
     """Shortcut to retrieve OpenAPI spec from ``aiohttp.web`` application.
 
     ``ConfigruationError`` raises if :class:`aiohttp.web.Application` does not

--- a/src/rororo/openapi/views.py
+++ b/src/rororo/openapi/views.py
@@ -1,8 +1,12 @@
+import json
 import logging
+from json import JSONEncoder
+from typing import Any
 
 import yaml
 from aiohttp import web
 from aiohttp_middlewares import error_context
+from openapi_core.spec.paths import SpecPath
 
 from ..annotations import MappingStrStr
 from .exceptions import ConfigurationError, OpenAPIError
@@ -10,6 +14,13 @@ from .utils import get_openapi_schema
 
 
 logger = logging.getLogger(__name__)
+
+
+class SpecPathEncoder(JSONEncoder):
+    def default(self, obj: Any) -> Any:
+        if isinstance(obj, SpecPath):
+            return obj.content()
+        return super().default(obj)
 
 
 async def default_error_handler(request: web.Request) -> web.Response:
@@ -27,6 +38,7 @@ async def default_error_handler(request: web.Request) -> web.Response:
             context.data,
             status=context.status,
             headers=headers,
+            dumps=lambda o: json.dumps(o, cls=SpecPathEncoder),
         )
 
 

--- a/tests/rororo/test_openapi.py
+++ b/tests/rororo/test_openapi.py
@@ -203,7 +203,11 @@ async def test_any_object_request_body(aiohttp_client, schema_path):
         (
             {},
             422,
-            {"detail": [{"loc": ["body"], "message": "[] is too short"}]},
+            {
+                "detail": [
+                    {"loc": ["body"], "message": "{} is not of type array"}
+                ]
+            },
         ),
         (
             [],

--- a/tests/rororo/test_openapi_exceptions.py
+++ b/tests/rororo/test_openapi_exceptions.py
@@ -1,7 +1,9 @@
 import pytest
-from openapi_core.schema.exceptions import OpenAPIMappingError
-from openapi_core.schema.media_types.exceptions import OpenAPIMediaTypeError
-from openapi_core.schema.parameters.exceptions import OpenAPIParameterError
+from openapi_core.exceptions import (
+    MissingRequestBodyError,
+    OpenAPIParameterError,
+)
+from openapi_core.templating.media_types.exceptions import MediaTypeFinderError
 
 from rororo.openapi.exceptions import (
     BadRequest,
@@ -102,20 +104,24 @@ def test_validation_error_from_dict_value_error():
 @pytest.mark.parametrize(
     "method, error, expected_loc",
     (
-        (ValidationError.from_request_errors, OpenAPIMappingError(), ["body"]),
-        (
-            ValidationError.from_response_errors,
-            OpenAPIMappingError(),
-            ["response"],
-        ),
         (
             ValidationError.from_request_errors,
-            OpenAPIMediaTypeError(),
+            MissingRequestBodyError(),
             ["body"],
         ),
         (
             ValidationError.from_response_errors,
-            OpenAPIMediaTypeError(),
+            MissingRequestBodyError(),
+            ["response"],
+        ),
+        (
+            ValidationError.from_request_errors,
+            MediaTypeFinderError(),
+            ["body"],
+        ),
+        (
+            ValidationError.from_response_errors,
+            MediaTypeFinderError(),
             ["response"],
         ),
         (


### PR DESCRIPTION
#149
So, it cannot be updated to v0.14.2 due to missing some features (like `RequestValidator._get_headers`), so we should wait for the next release

TODO:
- [ ] Update typing
- [ ] SecurityError handling: it checks all available authentication methods of the operation, and raises InvalidSecurity from openapi-core, if no one passes. So Idk how to properly raise rororo security errors, using new openapi-core api
- [ ] 2 tests are not yet passed: `tests/rororo/test_openapi.py::test_optional_security_scheme`. Response headers always dont have the auth header

