### PR TITLE
fix(openapi): Do not handle redirection errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,15 +37,6 @@ $(DOCS_DIR)/requirements.txt: poetry.lock
 $(DOCS_DIR)/requirements-sphinx.txt: $(DOCS_DIR)/requirements-sphinx.in
 	$(PIP_COMPILE) -Ur --allow-unsafe $(DOCS_DIR)/requirements-sphinx.in
 
-.PHONY: example
-example: install
-ifeq ($(EXAMPLE),)
-	@echo "USAGE: make $@ EXAMPLE=(hobotnica|petstore|simulations|todobackend)"
-	@exit 1
-else
-	PYTHONPATH=$(PYTHONPATH) $(PYTHON_BIN) -m aiohttp.web $(EXAMPLE).app:create_app
-endif
-
 .PHONY: install
 install: install-python
 
@@ -60,6 +51,19 @@ lint-only: lint-python-only
 
 .PHONY: list-outdated
 list-outdated: list-outdated-python
+
+.PHONY: run-example
+run-example: install
+ifeq ($(EXAMPLE),)
+	@echo "USAGE: make $@ EXAMPLE=(hobotnica|petstore|simulations|todobackend)"
+	@exit 1
+else
+	PYTHONPATH=examples/$(EXAMPLE)/src/ $(PYTHON_BIN) -m aiohttp.web $(EXAMPLE).app:create_app
+endif
+
+.PHONY: run-example-%
+run-example-%: install
+	@$(MAKE) run-example EXAMPLE=$(subst run-example-,,$@)
 
 .PHONY: test
 test: install clean validate test-only

--- a/examples/hobotnica/src/hobotnica/app.py
+++ b/examples/hobotnica/src/hobotnica/app.py
@@ -20,7 +20,7 @@ def create_app(
     if settings is None:
         settings = BaseSettings.from_environ()
 
-    return setup_openapi(
+    app = setup_openapi(
         setup_settings(
             web.Application(
                 middlewares=(
@@ -37,3 +37,5 @@ def create_app(
         cors_middleware_kwargs={"allow_all": True},
         cache_create_schema_and_spec=settings.is_test,
     )
+    print(f"{app.middlewares=}")
+    return app

--- a/examples/hobotnica/src/hobotnica/app.py
+++ b/examples/hobotnica/src/hobotnica/app.py
@@ -21,7 +21,7 @@ def create_app(
     if settings is None:
         settings = Settings.from_environ()
 
-    app = setup_openapi(
+    return setup_openapi(
         setup_settings(
             web.Application(
                 middlewares=(
@@ -39,5 +39,3 @@ def create_app(
         cache_create_schema_and_spec=settings.is_test,
         use_error_middleware=settings.use_error_middleware,
     )
-    print(f"{app.middlewares=}")
-    return app

--- a/examples/hobotnica/src/hobotnica/app.py
+++ b/examples/hobotnica/src/hobotnica/app.py
@@ -9,16 +9,17 @@ from aiohttp_middlewares import (
 )
 
 from hobotnica import views
-from rororo import BaseSettings, setup_openapi, setup_settings
+from hobotnica.settings import Settings
+from rororo import setup_openapi, setup_settings
 
 
 def create_app(
     argv: Union[List[str], None] = None,
     *,
-    settings: Union[BaseSettings, None] = None,
+    settings: Union[Settings, None] = None,
 ) -> web.Application:
     if settings is None:
-        settings = BaseSettings.from_environ()
+        settings = Settings.from_environ()
 
     app = setup_openapi(
         setup_settings(
@@ -36,6 +37,7 @@ def create_app(
         views.operations,
         cors_middleware_kwargs={"allow_all": True},
         cache_create_schema_and_spec=settings.is_test,
+        use_error_middleware=settings.use_error_middleware,
     )
     print(f"{app.middlewares=}")
     return app

--- a/examples/hobotnica/src/hobotnica/openapi.yaml
+++ b/examples/hobotnica/src/hobotnica/openapi.yaml
@@ -31,12 +31,23 @@ paths:
       security: []
       responses:
         <<: *default_responses
-        "200":
+        "200": &list_all_references_200_response
           description: "References list"
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/AnyObject"
+
+  "/public/references/deprecated":
+    get:
+      operationId: "list_all_references_deprecated"
+      summary: "List all references for UI needs"
+      deprecated: true
+      tags: ["public"]
+      security: []
+      responses:
+        <<: *default_responses
+        "200": *list_all_references_200_response
 
   "/repositories":
     get:

--- a/examples/hobotnica/src/hobotnica/settings.py
+++ b/examples/hobotnica/src/hobotnica/settings.py
@@ -1,0 +1,12 @@
+"""Settings for Hobotnica example."""
+
+import environ
+
+from rororo import BaseSettings
+
+
+@environ.config(prefix="", frozen=True)
+class Settings(BaseSettings):
+    use_error_middleware: bool = environ.bool_var(
+        name="USE_ERROR_MIDDLEWARE", default=True
+    )

--- a/examples/hobotnica/src/hobotnica/views.py
+++ b/examples/hobotnica/src/hobotnica/views.py
@@ -32,6 +32,11 @@ async def list_all_references(request: web.Request) -> web.Response:
 
 
 @operations.register
+async def list_all_references_deprecated(request: web.Request) -> web.Response:
+    raise web.HTTPFound(request.app.router["list_all_references"].url_for())
+
+
+@operations.register
 @login_required
 async def list_favorites_repositories(request: web.Request) -> web.Response:
     with openapi_context(request) as context:

--- a/src/rororo/openapi/middlewares.py
+++ b/src/rororo/openapi/middlewares.py
@@ -118,7 +118,7 @@ def openapi_middleware(
 
             return response
         except web.HTTPRedirection:
-            # Do not handle redirection errors, it is normal to
+            # Do not handle redirection errors, it is normal for
             # ``web.Application`` to ask to redirect to other page via
             # 301 <= X <= 399 error
             raise


### PR DESCRIPTION
Previously `rororo` has setup error middleware to handle `web.HTTPRedirection` errors as any other error, which is not valid behaviour as those errors should be treated as **redirections** instead.

Fixes: #191
